### PR TITLE
parseFloat in types.typesFromDynamo

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -52,12 +52,12 @@ types.typesFromDynamo = function(items) {
     return _(items).map(function(item) {
         _(item).each(function(v,k) {
             if(v.N) {
-                item[k] =parseInt(v.N, 10);
+                item[k] = parseFloat(v.N);
             } else if(v.S) {
                 item[k] =v.S;
             } else if(v.NS) {
                 item[k] = _(v.NS).map(function(i){
-                    return parseInt(i, 10);
+                    return parseFloat(i);
                 });
             } else if(v.SS) {
                 item[k] = _(v.SS).map(function(i){


### PR DESCRIPTION
Hey @mick was there a reason to use `parseInt`? This would truncate float values returned from dynamo.
