### PR TITLE
support NULL/NON_NULL conditionals

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -105,12 +105,12 @@ types.conditions = function(conditions) {
     var keyConditions = {};
     for(c in conditions) {
         var con = conditions[c];
-        var compare = Object.keys(con)[0];
+        var compare = typeof con == 'string' ? con : Object.keys(con)[0];
         keyConditions[c] = {};
         keyConditions[c].ComparisonOperator = compare;
         keyConditions[c].AttributeValueList = [];
         if(!Array.isArray(con[compare])) con[compare] = [con[compare]];
-        con[compare].forEach(function(avlist){
+        (con[compare] || []).forEach(function(avlist){
             keyConditions[c].AttributeValueList.push(types.toDynamoTypes({val:avlist}).val);
         });
         if(keyConditions[c].AttributeValueList.length === 0)

--- a/test/test.item.js
+++ b/test/test.item.js
@@ -366,13 +366,31 @@ test('update Item - with condition', function(t) {
 
     var actions = {put: {anotherkey: 'hello'}, delete: ['otherrange'], add: {counter: 1}};
     var d = dyno.updateItem(key, actions, {
-        expects: { "range": {"EQ" : [5] }}
+        expected: { 'range': {'EQ' : [5] }}
     }, function(err, resp){
         t.notOk(err);
+        t.equal(resp.anotherkey, 'hello', 'item has new attribute');
         t.end();
     });
 });
 
+
+test('update Item - with NOT_NULL condition', function(t) {
+
+    var key = { id: 'yo', range: 5 };
+
+    var actions = {put: {anotherkey2: 'hello2'}, delete: ['otherrange'], add: {counter: 1}};
+    var d = dyno.updateItem(key, actions, {
+        expected: {
+            'range': 'NOT_NULL',
+            'id': {'EQ': 'yo'}
+        }
+    }, function(err, resp){
+        t.notOk(err, 'no error');
+        t.equal(resp.anotherkey2, 'hello2', 'item has new attribute');
+        t.end();
+    });
+});
 
 test('update Item - with condition. fail conditions', function(t) {
 
@@ -380,7 +398,7 @@ test('update Item - with condition. fail conditions', function(t) {
 
     var actions = {put: {anotherkey: 'hello'}};
     var d = dyno.updateItem(key, actions, {
-    expected: { "anotherkey": { "EQ" : ['hi'] }}
+    expected: { 'anotherkey': { 'EQ' : ['hi'] }}
     }, function(err, resp){
         t.ok(err, 'should return error');
         t.equal(err.message, 'The conditional request failed');


### PR DESCRIPTION
closes #36 

This is now supported:

```
dyno.updateItem(key, actions, {
        expected: {
            'range': 'NOT_NULL',
            'id': {'EQ': 'yo'}
        }
    }, function(err, resp){});
```
