### PR TITLE
allow for deleting items from sets

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -9,6 +9,7 @@ types.toDynamoTypes = function(obj) {
 
     for (var key in obj) {
         var val = obj[key];
+        if(val === null) continue;
         if (typeof val === 'object' && !Array.isArray(val) && !Buffer.isBuffer(val)) {
             if (['N', 'S', 'B', 'NS', 'SS', 'BS'].indexOf(Object.keys(val)[0]) !== -1) {
                 continue;
@@ -78,8 +79,8 @@ types.typesFromDynamo = function(items) {
 function actionValue(attrs, action) {
     action = action.toUpperCase();
     attrs = types.toDynamoTypes(attrs);
-    if(action === 'DELETE') {
-        var deletes = {};
+    if(Array.isArray(attrs)) {
+        var deletes = [];
         attrs.forEach(function(a){
             deletes[a] = {Action: action};
         });
@@ -87,6 +88,7 @@ function actionValue(attrs, action) {
     } else {
         for(var a in attrs) {
             attrs[a] = {Action: action, Value: attrs[a]};
+            if(attrs[a].Value === null) delete attrs[a].Value;
         }
     }
     return attrs;

--- a/test/test.item.js
+++ b/test/test.item.js
@@ -258,9 +258,9 @@ test('query - callback, paging get all pages', function(t) {
 });
 
 test('query - callback, paging via prev/next', function(t) {
-    
+
     dyno.query({id:{'EQ':'yo'}}, {limit:1, pages:1}, firstResp);
-    
+
     function firstResp(err, items, metas) {
         t.equal(err, null);
         t.equal(items.length, 1);
@@ -369,7 +369,7 @@ test('update Item ', function(t) {
 test('update Item ', function(t) {
 
     var key = { id: 'yo', range: 5 };
-    var actions = {put: { anothernewkey: 'hi' }, delete: ['newkey'], add: {counter: 1}};
+    var actions = {put: { newset: ['a', 'b'] }, delete: ['newkey'], add: {counter: 1}};
     var d = dyno.updateItem(key, actions, function(err, resp){
         t.notOk(err);
         dyno.getItem(key, function(err, data){
@@ -377,8 +377,27 @@ test('update Item ', function(t) {
             t.deepEqual(data, {
                 "id" : "yo",
                 "range" : 5,
-                "anothernewkey" : "hi",
+                "newset" : ['a', 'b'],
                 "counter" : 1
+            }, 'item was really updated');
+            t.end();
+        });
+    });
+});
+
+
+test('update Item - delete from set', function(t) {
+
+    var key = { id: 'yo', range: 5 };
+    var actions = {delete: {newset: ['a'], 'counter':null}};
+    var d = dyno.updateItem(key, actions, function(err, resp){
+        t.notOk(err);
+        dyno.getItem(key, function(err, data){
+            t.notOk(err, 'no error');
+            t.deepEqual(data, {
+                "id" : "yo",
+                "range" : 5,
+                "newset" : ['b'],
             }, 'item was really updated');
             t.end();
         });


### PR DESCRIPTION
allows for deleting elements from sets with syntax like:

```
// Given a dynamo item:
{
 someattr: ['foo', 'bar', 'baz']
}

// Delete like:
{
            delete: {someattr: ['foo', 'bar']}
}


// Resulting item in dynamo:
{
 someattr: ['baz']
}

```
