### PR TITLE
prime calls to metadata service

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -6,6 +6,11 @@ module.exports = function(c){
 
     _(config).extend(c);
 
+    // attempt to prime the creds by getting them now instead of on
+    // the first request.
+    var creds = new AWS.Credentials();
+    creds.get();
+
     AWS.config.update({
         accessKeyId: c.accessKeyId,
         secretAccessKey: c.secretAccessKey,
@@ -17,6 +22,6 @@ module.exports = function(c){
     if (c.endpoint && c.endpoint !== '') opts.endpoint = new AWS.Endpoint(c.endpoint);
 
     config.dynamo = new AWS.DynamoDB(opts);
-    
+
     return config;
 };


### PR DESCRIPTION
by calling creds.get() this give a chance for creds to get cached before many requests at once try to get them 
