### PR TITLE
setImmediate so we dont get starved for IO

### DIFF
--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -46,7 +46,7 @@ module.exports = function(config) {
         if (opts.pages === undefined && callback) opts.pages = 1;
         if (!opts.pages) opts.pages = Infinity;
 
-        request(opts.start);
+        setImmediate(request, opts.start);
 
         function request(start) {
             var attempts = 0;


### PR DESCRIPTION
clients of this lib tend to do a lot of operation concurrently. This can cause dyno and aws-sdk to starve for IO, and for requests with short timeouts, like to ec2 metadata service to auth for the dynamo request can cause failures. 
