### PR TITLE
update aws-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Mick Thompson <mick@mick.im>",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.0.4",
+    "aws-sdk": "^2.1.5",
     "big.js": "^2.5.1",
     "event-stream": "^3.1.5",
     "queue-async": "~1.0.7",


### PR DESCRIPTION
2.1.5 prevents overwhelming IAM metadata service.