### PR TITLE
Wait for Kinesis response and emit error if it's enabled.

### DIFF
--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -1,6 +1,7 @@
 var types = require('./types');
 var stream = require('stream');
 var _ = require('underscore');
+var kinesisClient = require('./kinesis');
 
 var handledRequests = [
     'query',
@@ -127,13 +128,21 @@ module.exports = function(config) {
                     return streamRequest();
                 }
 
-                if (config.kinesis) {
-                    var kinesis = require('./kinesis')(type, config);
-                    if (kinesis.enabled) kinesis.put(params);
+                var kinesis = kinesisClient(type, config);
+                if (kinesis.enabled) {
+                    kinesis.put(params, function(err) {
+                        if (err && !callback) return readable.emit('error', err);
+                        if (err) return callback(err);
+                        done();
+                    });
+                } else {
+                    done();
                 }
 
-                if (read) readable.push(null);
-                if (callback) callback(null, items, metas);
+                function done() {
+                    if (read) readable.push(null);
+                    if (callback) callback(null, items, metas);
+                }
             }
         }
 

--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -131,7 +131,6 @@ module.exports = function(config) {
                 var kinesis = kinesisClient(type, config);
                 if (kinesis.enabled) {
                     kinesis.put(params, function(err) {
-                        if (err && !callback) return readable.emit('error', err);
                         if (err) return callback(err);
                         done();
                     });


### PR DESCRIPTION
Finally tracked down an error that we were swallowing and was able to fix it. This pull makes dyno wait for the Kinesis response before calling its callback and also returns any Kinesis requests to the caller.

Still looking into what's wrong with the failing test. Locally, I'm getting the same failure on both this branch and the `double-dyno` branch.

/cc @rclark 