### PR TITLE
Pass entire kinesisConfig to Kinesis constructor.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -23,10 +23,7 @@ module.exports = function(c){
         if (!Array.isArray(c.kinesisConfig.key)) throw badconfig('You must specify key attributes for the kinesis stream');
         if (!c.table) throw badconfig('You must specify the name of the table that feeds the kinesis stream');
 
-        var kinesisOpts = { region: c.kinesisConfig.region };
-        if (c.kinesisConfig.endpoint && c.kinesisConfig.endpoint !== '')
-            kinesisOpts = new AWS.Endpoint(c.kinesisConfig.endpoint);
-        config.kinesis = new AWS.Kinesis(kinesisOpts);
+        config.kinesis = new AWS.Kinesis(c.kinesisConfig);
     }
 
     // attempt to prime the creds by getting them now instead of on


### PR DESCRIPTION
- Don't unset region (which is required) if endpoint is set.
- Allows user to pass httpOptions (like agent) to the Kinesis
  constructor