### PR TITLE
Expose streaming interface to dyno.multi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 - LIVE=false
 - if test "${MSG#*'[live test]'}" != "$MSG"; then LIVE=true; fi
 script:
-- if [ "$LIVE" == "false" ]; then ./node_modules/.bin/tap test/index.js; fi
+- if [ "$LIVE" == "false" ]; then node test/index.js; fi
 - if [ "$LIVE" == "true" ]; then node test/live.tests.js; fi
 env:
   global:

--- a/lib/multi.js
+++ b/lib/multi.js
@@ -18,93 +18,93 @@ module.exports = function(read, write) {
       },
 
       getItem: function multiGetItem(key, opts, cb) {
-          if (!cb) {
+          if (typeof opts === 'function') {
               cb = opts;
               opts = {};
           }
-          opts = _(opts).clone();
+          opts = opts ? _(opts).clone() : {};
           if (opts.table) delete opts.table;
-          read.getItem(key, opts, cb);
+          return read.getItem(key, opts, cb);
       },
 
       putItem: function multiPutItem(doc, opts, cb) {
-          if (!cb) {
+          if (typeof opts === 'function') {
               cb = opts;
               opts = {};
           }
-          opts = _(opts).clone();
+          opts = opts ? _(opts).clone() : {};
           if (opts.table) delete opts.table;
-          write.putItem(doc, opts, cb);
+          return write.putItem(doc, opts, cb);
       },
 
       updateItem: function multiUpdateItem(key, doc, opts, cb) {
-          if (!cb) {
+          if (typeof opts === 'function') {
               cb = opts;
               opts = {};
           }
-          opts = _(opts).clone();
+          opts = opts ? _(opts).clone() : {};
           if (opts.table) delete opts.table;
-          write.updateItem(key, doc, opts, cb);
+          return write.updateItem(key, doc, opts, cb);
       },
 
       deleteItem: function multiDeleteItem(key, opts, cb) {
-          if (!cb) {
+          if (typeof opts === 'function') {
               cb = opts;
               opts = {};
           }
-          opts = _(opts).clone();
+          opts = opts ? _(opts).clone() : {};
           if (opts.table) delete opts.table;
-          write.deleteItem(key, opts, cb);
+          return write.deleteItem(key, opts, cb);
       },
 
       query: function multiQuery(conditions, opts, cb) {
-          if (!cb) {
+          if (typeof opts === 'function') {
               cb = opts;
               opts = {};
           }
-          opts = _(opts).clone();
+          opts = opts ? _(opts).clone() : {};
           if (opts.table) delete opts.table;
-          read.query(conditions, opts, cb);
+          return read.query(conditions, opts, cb);
       },
 
       scan: function multiScan(opts, cb) {
-          if (!cb) {
+          if (typeof opts === 'function') {
               cb = opts;
               opts = {};
           }
-          opts = _(opts).clone();
+          opts = opts ? _(opts).clone() : {};
           if (opts.table) delete opts.table;
-          read.scan(opts, cb);
+          return read.scan(opts, cb);
       },
 
       getItems: function multiGetItems(keys, opts, cb) {
-          if (!cb) {
+          if (typeof opts === 'function') {
               cb = opts;
               opts = {};
           }
-          opts = _(opts).clone();
+          opts = opts ? _(opts).clone() : {};
           if (opts.table) delete opts.table;
-          read.getItems(keys, opts, cb);
+          return read.getItems(keys, opts, cb);
       },
 
       putItems: function multiPutItems(items, opts, cb) {
-          if (!cb) {
+          if (typeof opts === 'function') {
               cb = opts;
               opts = {};
           }
-          opts = _(opts).clone();
+          opts = opts ? _(opts).clone() : {};
           if (opts.table) delete opts.table;
-          write.putItems(items, opts, cb);
+          return write.putItems(items, opts, cb);
       },
 
       deleteItems: function multiDeleteItems(itemKeys, opts, cb) {
-          if (!cb) {
+          if (typeof opts === 'function') {
               cb = opts;
               opts = {};
           }
-          opts = _(opts).clone();
+          opts = opts ? _(opts).clone() : {};
           if (opts.table) delete opts.table;
-          write.deleteItems(itemKeys, opts, cb);
+          return write.deleteItems(itemKeys, opts, cb);
       }
     };
 };


### PR DESCRIPTION
Return the results of `dynamoRequests` so that multi-dyno clients can do things like scan and query with streaming results.

Also looks like travis was broken, still trying to run tests with `tap`