### PR TITLE
Remove preloading of ec2 metadata credentials

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -25,13 +25,6 @@ module.exports = function(c) {
         config.kinesis = new AWS.Kinesis(c.kinesisConfig);
     }
 
-    // attempt to prime the creds by getting them now instead of on
-    // the first request.
-    var creds = new AWS.EC2MetadataCredentials({ httpOptions: { timeout: 5000 } });
-    creds.get(function(err) {
-        if (!err && creds) config.dynamo.config.credentials = creds;
-    });
-
     return config;
 };
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "dynalite": "^0.7.1",
-    "jscs": "^1.11.3",
+    "jscs": "1.11.3",
     "jshint": "^2.6.3",
     "kinesalite": "^0.4.0",
     "seedrandom": "^2.3.6",


### PR DESCRIPTION
This is no longer needed to due to upstream aws-sdk changes.