### PR TITLE
CLI adjustments

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -42,11 +42,16 @@ if (commands.indexOf(params.command) === -1) {
     process.exit(1);
 }
 
-params.region = params._[1].split('/')[0];
+params.region = params._[1] ? params._[1].split('/')[0] : null;
+if (!params.region) {
+    console.error('Error: Specify a region');
+    usage();
+    process.exit(1);
+}
 if (params.region === 'local') params.endpoint = 'http://localhost:4567';
 if (params.e) params.endpoint = params.e;
 
-params.table = params._[1].split('/')[1];
+params.table = params._[1] ? params._[1].split('/')[1] : null;
 if (!params.table && params.command !== 'tables') {
     console.error('Error: Specify a table name');
     usage();
@@ -147,7 +152,9 @@ if (params.command === 'tables') dyno.listTables(function(err, data) {
         console.error(err);
         process.exit(1);
     }
-    console.log(JSON.stringify(data));
+    data.TableNames.forEach(function(name) {
+        console.log(name);
+    });
 });
 
 // ----------------------------------

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-var argv = require('minimist')(process.argv.slice(2));
+var params = require('minimist')(process.argv.slice(2));
 var Dyno = require('../index.js');
 var queue = require('queue-async');
 var es = require('event-stream');
@@ -7,149 +7,204 @@ var es = require('event-stream');
 process.env.AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'fake';
 process.env.AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || 'fake';
 
-(function() {
-    var params = {};
+function usage() {
+    console.error('');
+    console.error('Usage: dyno <sub-command> <region>[/<tablename>]');
+    console.error('');
+    console.error('Valid sub-commands:');
+    console.error(' - tables: list available tables');
+    console.error(' - table: describe a single table');
+    console.error(' - export: print table description and data to stdout');
+    console.error(' - import: read table description and data into a new table');
+    console.error(' - scan: print data to stdout');
+    console.error(' - put: read data into an existing table');
+    console.error('');
+    console.error('Options:');
+    console.error(' - e | endpoint: endpoint for DynamoDB. Automatically set to http://localhost:4567 if region is `local`');
+    console.error('');
+    console.error('Examples:');
+    console.error('');
+    console.error('dyno scan us-east-1/my-table');
+    console.error('');
+    console.error('dyno export us-east-1/my-table | dyno import local/my-local-copy');
+}
 
-    params.region = argv._[0];
-    if (argv._[0] === 'local') params.endpoint = 'http://localhost:4567';
-    if (argv.e) params.endpoint = argv.e;
+if (params.help) {
+    usage();
+    process.exit(0);
+}
 
-    if (argv._[1] === 'tables') {
-        dyno = Dyno(params);
-        return dyno.listTables(output);
-    }
+params.command = params._[0];
+var commands = ['tables', 'table', 'export', 'import', 'scan', 'put'];
+if (commands.indexOf(params.command) === -1) {
+    console.error('Error: Use a valid sub-command. One of ' + commands.join(', '));
+    usage();
+    process.exit(1);
+}
 
-    if (!argv._[2]) error('No table set');
-    params.table = argv._[2];
+params.region = params._[1].split('/')[0];
+if (params.region === 'local') params.endpoint = 'http://localhost:4567';
+if (params.e) params.endpoint = params.e;
 
-    dyno = Dyno(params);
+params.table = params._[1].split('/')[1];
+if (!params.table && params.command !== 'tables') {
+    console.error('Error: Specify a table name');
+    usage();
+    process.exit(1);
+}
 
-    function describedTable(err, resp) {
-        if (err) return error(err);
+var dyno = Dyno(params);
 
-        var deleteAttributes = [
-            'CreationDateTime',
-            'IndexSizeBytes',
-            'IndexStatus',
-            'ItemCount',
-            'NumberOfDecreasesToday',
-            'TableSizeBytes',
-            'TableStatus',
-            'LastDecreaseDateTime',
-            'LastIncreaseDateTime'
-        ];
-
-        function replacer(key, value) {
-            if (deleteAttributes.indexOf(key) !== -1) {
-                return undefined;
-            }
-            return value;
-        }
-
-        console.log(JSON.stringify(resp.Table, replacer));
-        dyno.scan()
-            .pipe(stringifier)
-            .pipe(process.stdout)
-            .on('error', function(err) {
-                error(err);
-            })
-            .on('end', process.exit);
-    }
-
-    // Stringifies JSON objects and base64 encodes buffers
-    var stringifier = es.through(function(record) {
-        this.emit('data', JSON.stringify(record, function(key) {
-            var val = this[key];
-            if (Buffer.isBuffer(val)) return 'base64:' + val.toString('base64');
-            return val;
-        }) + '\n');
+// Transform stream to stringifies JSON objects and base64 encodes buffers
+var stringifier = es.through(function(record) {
+    var str = JSON.stringify(record, function(key, value) {
+        var val = this[key];
+        if (Buffer.isBuffer(val)) return 'base64:' + val.toString('base64');
+        return value;
     });
 
-    // Parses JSON strings and base64 decodes into buffers
-    var parser = es.through(function(record) {
-        record = JSON.parse(record);
+    this.emit('data', str + '\n');
+});
 
-        var val;
-        for (var key in record) {
-            val = record[key];
-            if (typeof val === 'string' && val.indexOf('base64:') === 0)
-                record[key] = new Buffer(val.split('base64:').pop(), 'base64');
+// Transform stream parses JSON strings and base64 decodes into buffers
+var parser = es.through(function(record) {
+    if (!record) return;
+
+    record = JSON.parse(record);
+
+    var val;
+    for (var key in record) {
+        val = record[key];
+        if (typeof val === 'string' && val.indexOf('base64:') === 0)
+            record[key] = new Buffer(val.split('base64:').pop(), 'base64');
+    }
+
+    this.emit('data', record);
+});
+
+// Remove unimportant table metadata from the description
+function cleanDescription(desc) {
+    var deleteAttributes = [
+        'CreationDateTime',
+        'IndexSizeBytes',
+        'IndexStatus',
+        'ItemCount',
+        'NumberOfDecreasesToday',
+        'TableSizeBytes',
+        'TableStatus',
+        'LastDecreaseDateTime',
+        'LastIncreaseDateTime'
+    ];
+
+    return JSON.stringify(desc.Table, function(key, value) {
+        if (deleteAttributes.indexOf(key) !== -1) {
+            return undefined;
         }
-
-        this.emit('data', record);
+        return value;
     });
-    // dyno table -t
-    if (argv._[1] === 'table') {
-        return dyno.describeTable(output);
-    }
+}
 
-    //describes the table, then scans and outputs all the data.
-    if (argv._[1] === 'export') {
-        dyno.describeTable(describedTable);
-    }
-
-    if (argv._[1] === 'scan') {
-        dyno.scan()
+function scan() {
+    dyno.scan()
         .pipe(stringifier)
         .pipe(process.stdout)
         .on('error', function(err) {
-            error(err);
-        })
-        .on('end', process.exit);
-    }
-
-    //describes the table, then scans and outputs all the data.
-    if (argv._[1] === 'import') {
-        var importQueue = queue(10);
-        var firstline = true;
-        process.stdin
-            .pipe(es.split())
-            .pipe(parser)
-            .pipe(es.through(function(data) {
-                if (firstline) {
-                    firstline = false;
-                    this.pause();
-                    data.TableName = params.table;
-                    dyno.createTable(data, function(err) {
-                        if (err) error(err);
-                        this.resume();
-                    }.bind(this));
-                } else {
-                    importQueue.defer(dyno.putItem, data);
-                }
-            }))
-            .on('error', function(err) {
-                error(err);
-            });
-        importQueue.awaitAll(function(err) {
-            if (err) error(err);
+            console.error(err);
+            process.exit(1);
         });
-    }
-
-    if (argv._[1] === 'put') {
-        var putQueue = queue(10);
-        process.stdin
-            .pipe(es.split())
-            .pipe(parser)
-            .pipe(es.through(function(data) {
-                putQueue.defer(dyno.putItem, data);
-            }))
-            .on('error', function(err) {
-                error(err);
-            });
-        putQueue.awaitAll(function(err) {
-            if (err) error(err);
-        });
-    }
-
-})();
-
-function output(err, resp) {
-    if (err) console.error(err);
-    if (resp) console.log(JSON.stringify(resp));
-    process.exit(0);
 }
-function error(msg) {
-    console.error(msg);
-    process.exit(1);
+
+function Importer(withTable) {
+    var firstline = !!withTable;
+    var q = queue(10);
+
+    var importer = es.through(function(data) {
+        if (firstline) {
+            firstline = false;
+            this.pause();
+            data.TableName = params.table;
+            dyno.createTable(data, function(err) {
+                if (err) error(err);
+                this.resume();
+            }.bind(this));
+        } else {
+            q.defer(dyno.putItem, data);
+        }
+    });
+
+    q.awaitAll(function(err) {
+        if (err) importer.emit('error', err);
+    });
+
+    return importer;
+}
+
+// ----------------------------------
+// List tables
+// ----------------------------------
+if (params.command === 'tables') dyno.listTables(function(err, data) {
+    if (err) {
+        console.error(err);
+        process.exit(1);
+    }
+    console.log(JSON.stringify(data));
+});
+
+// ----------------------------------
+// Describe table
+// ----------------------------------
+if (params.command === 'table') dyno.describeTable(function(err, data) {
+    if (err) {
+        console.error(err);
+        process.exit(1);
+    }
+    console.log(JSON.stringify(data));
+});
+
+// ----------------------------------
+// Export table
+// ----------------------------------
+if (params.command === 'export') {
+    return dyno.describeTable(function(err, desc) {
+        if (err) {
+            console.error(err);
+            process.exit(1);
+        }
+
+        console.log(cleanDescription(desc));
+        scan();
+    });
+}
+
+// ----------------------------------
+// Scan table
+// ----------------------------------
+if (params.command === 'scan') scan();
+
+// ----------------------------------
+// Import table
+// ----------------------------------
+if (params.command === 'import') {
+    process.stdin
+        .pipe(es.split())
+        .pipe(parser)
+        .pipe(Importer(true))
+        .on('error', function(err) {
+            console.error(err);
+            process.exit(1);
+        });
+}
+
+// ----------------------------------
+// Import data
+// ----------------------------------
+if (params.command === 'put') {
+    process.stdin
+        .pipe(es.split())
+        .pipe(parser)
+        .pipe(Importer(false))
+        .on('error', function(err) {
+            console.error(err);
+            process.exit(1);
+        });
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -17,7 +17,7 @@ types.toDynamoTypes = function(obj) {
             if (['N', 'S', 'B', 'NS', 'SS', 'BS'].indexOf(Object.keys(val)[0]) !== -1) {
                 continue;
             } else {
-                throw new Error('Unknown attribute ', val);
+                throw new Error('Unknown attribute ' + val);
             }
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 require('./setup')();
 require('./test.batch');
 require('./test.convertTypes');
+require('./test.cli');
 require('./test.item');
 require('./test.table');
 require('./test.kinesis');

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -1,0 +1,314 @@
+var path = require('path');
+var _ = require('underscore');
+var cli = path.resolve(__dirname, '..', 'bin', 'cli.js');
+var exec = require('child_process').exec;
+
+var fixtures = require('./fixtures');
+var setup = require('./setup')();
+var test = setup.test;
+var dyno = setup.dyno;
+
+// use --verbose to print cli output to terminal during the test run
+var verbose = process.argv.indexOf('--verbose') > -1;
+
+function runCli(params, callback) {
+    var options = {
+        env: _(process.env).clone(),
+        cwd: path.resolve(__dirname, '..')
+    };
+
+    options.env.AWS_ACCESS_KEY_ID = 'fake';
+    options.env.AWS_SECRET_ACCESS_KEY = 'fake';
+    options.env.AWS_SESSION_TOKEN = 'fake';
+
+    var cmd = _.union([cli], params).join(' ');
+    var proc = exec(cmd, options, callback);
+
+    if (verbose) {
+        proc.stdout.pipe(process.stdout);
+        proc.stderr.pipe(process.stderr);
+    }
+
+    return proc;
+}
+
+var expectedTable = {
+    Table: {
+        AttributeDefinitions: [
+            { AttributeName: 'id', AttributeType: 'S' },
+            { AttributeName: 'range', AttributeType: 'N' }
+        ],
+        TableName: setup.tableName,
+        ProvisionedThroughput: {
+            WriteCapacityUnits: 1,
+            ReadCapacityUnits: 1,
+            NumberOfDecreasesToday: 0
+        },
+        KeySchema: [
+            { AttributeName: 'id', KeyType: 'HASH' },
+            { AttributeName: 'range', KeyType: 'RANGE' }
+        ],
+        CreationDateTime: '[TIMESTAMP]',
+        ItemCount: 0,
+        TableSizeBytes: 0,
+        TableStatus: 'ACTIVE'
+    }
+};
+
+var cleanedTable = _.omit(JSON.parse(JSON.stringify(expectedTable.Table)), [
+    'CreationDateTime',
+    'IndexSizeBytes',
+    'IndexStatus',
+    'ItemCount',
+    'TableSizeBytes',
+    'TableStatus',
+    'LastDecreaseDateTime',
+    'LastIncreaseDateTime'
+]);
+
+delete cleanedTable.ProvisionedThroughput.NumberOfDecreasesToday;
+
+test('cli: help', function(assert) {
+    runCli(['--help'], function(err, stdout, stderr) {
+        assert.ifError(err, 'cli success');
+        assert.notOk(stdout, 'nothing logged to stdout');
+        assert.ok(/Usage: dyno/.test(stderr), 'usage info printed to stderr');
+        assert.end();
+    });
+});
+
+test('cli: invalid command', function(assert) {
+    runCli(['ham', 'local/' + setup.tableName], function(err, stdout, stderr) {
+        assert.equal(err.code, 1, 'cli exit 1');
+        assert.notOk(stdout, 'nothing logged to stdout');
+        assert.ok(/Error: Use a valid sub-command/.test(stderr), 'error printed to stderr');
+        assert.end();
+    });
+});
+
+test('cli: invalid command', function(assert) {
+    runCli(['table'], function(err, stdout, stderr) {
+        assert.equal(err.code, 1, 'cli exit 1');
+        assert.notOk(stdout, 'nothing logged to stdout');
+        assert.ok(/Error: Specify a region/.test(stderr), 'error printed to stderr');
+        assert.end();
+    });
+});
+
+test('cli: no table specified', function(assert) {
+    runCli(['table', 'local'], function(err, stdout, stderr) {
+        assert.equal(err.code, 1, 'cli exit 1');
+        assert.notOk(stdout, 'nothing logged to stdout');
+        assert.ok(/Error: Specify a table name/.test(stderr), 'error printed to stderr');
+        assert.end();
+    });
+});
+
+test('cli: setup', setup.setup());
+test('cli: setup table', setup.setupTable);
+test('cli: list tables', function(assert) {
+    runCli(['tables', 'local'], function(err, stdout, stderr) {
+        assert.ifError(err, 'cli success');
+        assert.ok((new RegExp(setup.tableName)).test(stdout), 'printed table name');
+        assert.end();
+    });
+});
+test('cli: teardown', setup.teardown);
+
+test('cli: setup', setup.setup());
+test('cli: setup table', setup.setupTable);
+test('cli: describe table', function(assert) {
+    runCli(['table', 'local/' + setup.tableName], function(err, stdout, stderr) {
+        assert.ifError(err, 'cli success');
+
+        var found = JSON.parse(stdout.trim());
+        found.Table.CreationDateTime = '[TIMESTAMP]';
+
+        assert.deepEqual(found, expectedTable, 'expected table information printed to stdout');
+        assert.end();
+    });
+});
+test('cli: teardown', setup.teardown);
+
+test('cli: setup', setup.setup());
+test('cli: setup table', setup.setupTable);
+test('cli: export table', function(assert) {
+    var records = fixtures.randomItems(10);
+    dyno.putItems(records, function(err) {
+        if (err) {
+            assert.ifError(err, 'failed to put records');
+            return assert.end();
+        }
+
+        runCli(['export', 'local/' + setup.tableName], function(err, stdout, stderr) {
+            assert.ifError(err, 'cli success');
+
+            var results = stdout.trim().split('\n');
+
+            var table = JSON.parse(results.shift());
+
+            assert.deepEqual(table, cleanedTable, 'printed cleaned table definition to stdout');
+
+            var expectedRecords = records.map(function(record) {
+                return JSON.stringify(record);
+            });
+
+            var intersection = _.intersection(expectedRecords, results);
+            assert.equal(intersection.length, results.length, 'printed records to stdout');
+            assert.end();
+        });
+    });
+});
+test('cli: teardown', setup.teardown);
+
+test('cli: setup', setup.setup());
+test('cli: setup table', setup.setupTable);
+test('cli: scan table', function(assert) {
+    var records = fixtures.randomItems(10);
+    dyno.putItems(records, function(err) {
+        if (err) {
+            assert.ifError(err, 'failed to put records');
+            return assert.end();
+        }
+
+        runCli(['scan', 'local/' + setup.tableName], function(err, stdout, stderr) {
+            assert.ifError(err, 'cli success');
+
+            var results = stdout.trim().split('\n');
+
+            var expectedRecords = records.map(function(record) {
+                return JSON.stringify(record);
+            });
+
+            var intersection = _.intersection(expectedRecords, results);
+            assert.equal(intersection.length, results.length, 'printed records to stdout');
+            assert.end();
+        });
+    });
+});
+test('cli: teardown', setup.teardown);
+
+test('cli: setup', setup.setup());
+test('cli: import table', function(assert) {
+    var records = fixtures.randomItems(10);
+    var serialized = _.union([cleanedTable], records).map(function(line) {
+        return JSON.stringify(line);
+    }).join('\n');
+
+    var proc = runCli(['import', 'local/' + setup.tableName], function(err, stdout, stderr) {
+        assert.ifError(err, 'cli success');
+        dyno.scan({ pages: 0 }, function(err, items) {
+            if (err) {
+                assert.ifError(err, 'failed to import table + data');
+                return assert.end();
+            }
+
+            var expectedRecords = records.map(function(record) {
+                return JSON.stringify(record);
+            });
+
+            items = items.map(function(record) {
+                return JSON.stringify(record);
+            });
+
+            var intersection = _.intersection(expectedRecords, items);
+            assert.equal(intersection.length, items.length, 'loaded records into table');
+            assert.end();
+        });
+    });
+
+    proc.stdin.write(serialized);
+    proc.stdin.end();
+});
+test('cli: teardown', setup.teardown);
+
+test('cli: setup', setup.setup());
+test('cli: setup table', setup.setupTable);
+test('cli: import data', function(assert) {
+    var records = fixtures.randomItems(10);
+    var serialized = records.map(function(line) {
+        return JSON.stringify(line);
+    }).join('\n');
+
+    var proc = runCli(['put', 'local/' + setup.tableName], function(err, stdout, stderr) {
+        assert.ifError(err, 'cli success');
+        dyno.scan({ pages: 0 }, function(err, items) {
+            if (err) {
+                assert.ifError(err, 'failed to import table + data');
+                return assert.end();
+            }
+
+            var expectedRecords = records.map(function(record) {
+                return JSON.stringify(record);
+            });
+
+            items = items.map(function(record) {
+                return JSON.stringify(record);
+            });
+
+            var intersection = _.intersection(expectedRecords, items);
+            assert.equal(intersection.length, items.length, 'loaded records into table');
+            assert.end();
+        });
+    });
+
+    proc.stdin.write(serialized);
+    proc.stdin.end();
+});
+test('cli: teardown', setup.teardown);
+
+test('cli: setup', setup.setup());
+test('cli: setup table', setup.setupTable);
+test('cli: export complicated record', function(assert) {
+    var record = {
+        id: 'id:1',
+        range: 1,
+        buffer: new Buffer('hello world!'),
+        array: [0, 1, 2],
+        newline: '0\n1'
+    };
+
+    dyno.putItem(record, function(err) {
+        if (err) {
+            assert.ifError(err, 'failed to put record');
+            return assert.end();
+        }
+
+        runCli(['scan', 'local/' + setup.tableName], function(err, stdout, stderr) {
+            assert.ifError(err, 'cli success');
+            assert.equal(stdout.trim(), '{"id":"id:1","range":1,"buffer":"base64:aGVsbG8gd29ybGQh","array":[0,1,2],"newline":"0\\n1"}', 'printed record to stdout');
+            assert.end();
+        });
+    });
+});
+test('cli: teardown', setup.teardown);
+
+test('cli: setup', setup.setup());
+test('cli: setup table', setup.setupTable);
+test('cli: import complicated record', function(assert) {
+    var expected = {
+        id: 'id:1',
+        range: 1,
+        buffer: new Buffer('hello world!'),
+        array: [0, 1, 2],
+        newline: '0\n1'
+    };
+
+    var proc = runCli(['put', 'local/' + setup.tableName], function(err, stdout, stderr) {
+        assert.ifError(err, 'cli success');
+
+        dyno.scan(function(err, items) {
+            if (err) {
+                assert.ifError(err, 'failed to scan table');
+                return assert.end();
+            }
+            assert.equal(items.length, 1, 'loaded one record');
+            assert.deepEqual(items[0], expected, 'loaded expected record');
+            assert.end();
+        });
+    });
+
+    proc.stdin.write('{"id":"id:1","range":1,"buffer":"base64:aGVsbG8gd29ybGQh","array":[0,1,2],"newline":"0\\n1"}');
+    proc.stdin.end();
+});
+test('cli: teardown', setup.teardown);


### PR DESCRIPTION
Adds base64-encoding for buffers in the dynamodb records exported via CLI. Heavy refactoring in `cli.js`. + adjusts CLI arguments, for example:
```
dyno scan us-east-1/my-table
dyno tables us-east-1
dyno export us-east-1/my-table | dyno import eu-west-1/my-replica
```

@mick what do you think of doing the parameters like this? It feels a little more intuitive to me.

**Needs**
- cli tests


