### PR TITLE
Opt-in to dyno-manged throughput retries

### DIFF
--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -48,9 +48,13 @@ module.exports = function(config) {
         };
 
         // 24 attempts is a hard cut-off at about 1 min delay between retries
-        var defaultAttempts = config.retryAggressively ? 24 : 0;
-        var maxAttempts = _.isNumber(opts.throughputAttempts) ?
-            Math.min(opts.throughputAttempts, 24) : defaultAttempts;
+        var throughputAttempts = _.isNumber(opts.throughputAttempts) ?
+            Math.min(opts.throughputAttempts, 24) : _.isNumber(config.throughputAttempts) ?
+            Math.min(config.throughputAttempts, 24) : 10;
+
+        var batchAttempts = _.isNumber(opts.batchAttempts) ?
+            Math.min(opts.batchAttempts, 24) : _.isNumber(config.batchAttempts) ?
+            Math.min(config.batchAttempts, 24) : 10;
 
         var params = _(parameters).clone();
         var page = 0;
@@ -73,12 +77,18 @@ module.exports = function(config) {
             var attempts = 0;
             if (start) params.ExclusiveStartKey = start;
 
-            config.dynamo[type](params, response);
+            config.dynamo[type](params, response)
+                .on('retry', function(resp) {
+                    if (resp.error && resp.error.code === 'ProvisionedThroughputExceededException') {
+                        if (resp.retryCount < throughputAttempts) resp.error.retryable = true;
+                        else resp.error.retryable = false;
+                    }
+                });
 
             function response(err, resp) {
                 attempts++;
 
-                function throttledRetry(requestParams) {
+                function throttledRetry(maxAttempts, requestParams) {
                     if (attempts < maxAttempts) {
                         return setTimeout(function() {
                             config.dynamo[type](requestParams, response);
@@ -92,16 +102,13 @@ module.exports = function(config) {
                     }
                 }
 
-                if (err && err.code === 'ProvisionedThroughputExceededException')
-                    return throttledRetry(params);
-
                 if (err && !callback) return readable.emit('error', err);
                 if (err) return callback(err);
 
                 var unprocessed = resp.UnprocessedKeys || resp.UnprocessedItems;
                 if (unprocessed && Object.keys(unprocessed).length > 0) {
                     var newParams = _({}).extend(params, { RequestItems: unprocessed });
-                    return throttledRetry(newParams);
+                    return throttledRetry(batchAttempts, newParams);
                 }
 
                 if (resp.Item) resp.Items = [resp.Item];

--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -80,6 +80,9 @@ module.exports = function(config) {
             config.dynamo[type](params, response)
                 .on('retry', function(resp) {
                     if (resp.error && resp.error.code === 'ProvisionedThroughputExceededException') {
+                        resp.maxRetries = throughputAttempts;
+                        resp.error.retryDelay = 50 * Math.pow(2, resp.retryCount - 1);
+
                         if (resp.retryCount < throughputAttempts) resp.error.retryable = true;
                         else resp.error.retryable = false;
                     }

--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -48,8 +48,9 @@ module.exports = function(config) {
         };
 
         // 24 attempts is a hard cut-off at about 1 min delay between retries
+        var defaultAttempts = config.retryAggressively ? 24 : 0;
         var maxAttempts = _.isNumber(opts.throughputAttempts) ?
-            Math.min(opts.throughputAttempts, 24) : 24;
+            Math.min(opts.throughputAttempts, 24) : defaultAttempts;
 
         var params = _(parameters).clone();
         var page = 0;

--- a/test/test.throughput.js
+++ b/test/test.throughput.js
@@ -1,3 +1,4 @@
+var AWS = require('aws-sdk');
 var s = require('./setup')(true);
 var test = s.test;
 var dynamoRequest = require('../lib/dynamoRequest');
@@ -38,7 +39,7 @@ test('slow enough', function(t) {
 
 test('too fast', function(t) {
     var items = fixtures.randomItems(10, 63 * 1024);
-    var q = queue();
+    var q = queue(1);
 
     items.forEach(function(item) {
         q.defer(dyno.putItem, item, { throughputAttempts: 1 });

--- a/test/test.throughput.js
+++ b/test/test.throughput.js
@@ -64,7 +64,7 @@ test('should throttle', function(t) {
 
     q.awaitAll(function(err, results) {
         // Couldn't throttle enough. Check that at least throttling was tried
-        if (err) t.equal(err.attempts, 2, 'tried to throttle requests');
+        if (err) t.equal(err.retryDelay, 100, 'tried to throttle requests');
 
         // Throttled enough
         else t.equal(results.length, items.length, 'all requests completed');


### PR DESCRIPTION
Dyno's retries on `ProvisionedThroughputExceededException` errors may be too aggressive for some situations. This PR requires you to opt-in to dyno-managed retries.  

- by setting `config.retryAggressively = true` when you configure your dyno instance
- by setting `options.throughputAttempts = X` when you make any individual request

If you set neither of these things, dyno itself will not retry any requests that fail with a throughput exception. _However the aws-sdk will retry_ in these situations up to 10 times over the course of ~30 seconds.

@willwhite @mick is this sufficient, or do you think that we ought to expose an option to entirely disable retries on throughput throttling?