### PR TITLE
Stream _read asyncify

### DIFF
--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -43,7 +43,7 @@ module.exports = function(config) {
             read = true;
             if (!status) {
                 status = true;
-                streamRequest();
+                setImmediate(streamRequest);
             }
         };
 


### PR DESCRIPTION
This gives the node.js event loop some breathing room between stream `_read` calls. 

Each call to `_read` [pushes another item into the buffer](https://github.com/mapbox/dyno/blob/c549c2d52b6e4ac090287c346fe28f4a12115373/lib/dynamoRequest.js#L69). Each `push` event _can_ trigger the readable stream itself to make another `_read` call. In the event that this is happening synchronously, there may be no room in the event loop to fire and receive [another DynamoDB request](https://github.com/mapbox/dyno/blob/c549c2d52b6e4ac090287c346fe28f4a12115373/lib/dynamoRequest.js#L71).

If that happens to occur at a time when the stream's `_readableState.buffer` is filled beyond its `highWaterMark`, each `_read` operation will keep `status = false` while `item.length` continues to drop one item at a time. Eventually you'll reach the point that `stats === false && item.length === 0` and [the readable stream will end](https://github.com/mapbox/dyno/blob/c549c2d52b6e4ac090287c346fe28f4a12115373/lib/dynamoRequest.js#L72) before having had a chance to complete all its DynamoDB reads.

cc @mick 