### PR TITLE
Refactor streaming mode

### DIFF
--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -34,17 +34,26 @@ module.exports = function(config) {
 
         var items = [];
         var metas = [];
-        var read = false;
-        var status = true;
+        var streamMode = !callback;
+        var readMore = true;
         var currentKey;
 
         var readable = new stream.Readable({objectMode:true});
         readable._read = function(size) {
-            read = true;
-            if (!status) {
-                status = true;
-                setImmediate(streamRequest);
-            }
+            // make records readable until hit high water mark or runs out
+            var status = true;
+            while (status && items.length)
+                status = readable.push(items.shift());
+
+            // hit high water mark, subsequent calls will bring it below
+            if (items.length) return;
+
+            // if there's nothing more to request, end the stream
+            if (!readMore) return readable.push(null);
+
+            // if below high water mark, make a dynamodb request, but make sure
+            // only one request is outstanding at a time
+            if (status && !readable.pending) request(currentKey);
         };
 
         // 24 attempts is a hard cut-off at about 1 min delay between retries
@@ -62,20 +71,13 @@ module.exports = function(config) {
         if (opts.pages === undefined && callback) opts.pages = 1;
         if (!opts.pages) opts.pages = Infinity;
 
-        request(opts.start);
-
-        function streamRequest() {
-            while (status && items.length > 0) {
-                status = readable.push(items.shift());
-            }
-            if (status && currentKey && page < opts.pages) return request(currentKey);
-            if (items.length === 0 || (!currentKey &&  page >= opts.pages)) readable.push(null);
-        }
+        if (!streamMode) request(opts.start);
 
         function request(start) {
             currentKey = false;
             var attempts = 0;
             if (start) params.ExclusiveStartKey = start;
+            if (streamMode) readable.pending = true;
 
             config.dynamo[type](params, response)
                 .on('retry', function(resp) {
@@ -89,6 +91,7 @@ module.exports = function(config) {
                 });
 
             function response(err, resp) {
+                if (streamMode) readable.pending = false;
                 attempts++;
 
                 function throttledRetry(maxAttempts, requestParams) {
@@ -133,26 +136,16 @@ module.exports = function(config) {
 
                 page++;
                 currentKey = resp.LastEvaluatedKey;
-                if (!read && page < opts.pages && currentKey) {
-                    return request(currentKey);
-                } else if (read) {
-                    return streamRequest();
-                }
+                readMore = !!currentKey && page < opts.pages;
+                if (streamMode) return readable._read();
+                else if (readMore) return request(currentKey);
 
                 var kinesis = kinesisClient(type, config);
-                if (kinesis.enabled) {
-                    kinesis.put(params, function(err) {
-                        if (err) return callback(err);
-                        done();
-                    });
-                } else {
-                    done();
-                }
-
-                function done() {
-                    if (read) readable.push(null);
-                    if (callback) callback(null, items, metas);
-                }
+                if (!kinesis.enabled) return callback(null, items, metas);
+                kinesis.put(params, function(err) {
+                    if (err) return callback(err);
+                    callback(null, items, metas);
+                });
             }
         }
 


### PR DESCRIPTION
I think that this clarifies the readable stream code in dynamoRequest.js in a good way. I can confirm that this code avoids the root of the problem that https://github.com/mapbox/dyno/pull/73 bypassed. 

In this refactor the stream cannot `end` until a DynamoDB response has come back without a `LastEvaluatedKey`.

Definitely interested in your thoughts on this @mick.