### PR TITLE
Adds backend request events

### DIFF
--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -91,7 +91,10 @@ module.exports = function(config) {
                 });
 
             function response(err, resp) {
-                if (streamMode) readable.pending = false;
+                if (streamMode) {
+                    readable.pending = false;
+                    readable.emit('dbrequest', params, resp);
+                }
                 attempts++;
 
                 function throttledRetry(maxAttempts, requestParams) {

--- a/test/test.item.js
+++ b/test/test.item.js
@@ -169,14 +169,19 @@ test('setup items', function(t) {
 });
 
 test('scan - stream', function(t) {
-
-    dyno.scan().pipe(es.writeArray(function(err, data) {
-        t.equal(err, null, 'no errors');
-        t.equal(data.length, 4, 'right number of items');
-        t.deepEqual(_(data[0]).omit('blob'), {id: 'yo', range:5}, 'first item');
-        t.deepEqual(_(data[3]).omit('blob'), {id: 'yo', range:8}, 'last item');
-        t.end();
-    }));
+    dyno.scan()
+        .on('dbrequest', function(params, response) {
+            t.pass('fires dbrequest event');
+            t.ok(params.TableName, 'provides request parameters');
+            t.equal(response.Count, response.Items.length, 'provides dynamodb response');
+        })
+        .pipe(es.writeArray(function(err, data) {
+            t.equal(err, null, 'no errors');
+            t.equal(data.length, 4, 'right number of items');
+            t.deepEqual(_(data[0]).omit('blob'), {id: 'yo', range:5}, 'first item');
+            t.deepEqual(_(data[3]).omit('blob'), {id: 'yo', range:8}, 'last item');
+            t.end();
+        }));
 
 });
 


### PR DESCRIPTION
When streaming a request, adds `dbrequest` events that are fired each time a response is received from DynamoDB. Handler is passed the request parameters and the response object. This is useful if you need to diagnose the rates at which your streaming application is making backend requests.