### PR TITLE
Configurable highwatermark, max 1000

### DIFF
--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -38,7 +38,11 @@ module.exports = function(config) {
         var readMore = true;
         var currentKey;
 
-        var readable = new stream.Readable({objectMode:true});
+        var readable = new stream.Readable({
+            objectMode:true,
+            highWaterMark: Math.min(1000, opts.highWaterMark || Infinity)
+        });
+
         readable._read = function(size) {
             // make records readable until hit high water mark or runs out
             var status = true;


### PR DESCRIPTION
Sets a default highWaterMark of 1000, allows you to scale that back with per-request options. 16834 is the readable-stream's default, and this is too high: something like a scan operation will bomb dynamodb with a bunch of requests at first before the stream api has a chance to start throttling.

1000 seemed like a reasonable max value: with a max item size of 400k in dynamodb, this means the most that would ever get buffered in memory is 400MB of data.