### PR TITLE
CLI write fixes

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -4,7 +4,6 @@ var Dyno = require('../index.js');
 var queue = require('queue-async');
 var es = require('event-stream');
 var stream = require('stream');
-var zlib = require('zlib');
 var fs = require('fs');
 
 process.env.AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'fake';
@@ -62,9 +61,6 @@ if (!params.table && params.command !== 'tables') {
 }
 
 var dyno = Dyno(params);
-
-var input = params._[2] ?
-    fs.createReadStream(params._[2]).pipe(zlib.createGunzip()) : process.stdin;
 
 // Transform stream to stringifies JSON objects and base64 encodes buffers
 function Stringifier() {
@@ -259,7 +255,7 @@ if (params.command === 'scan') scan();
 // Import table
 // ----------------------------------
 if (params.command === 'import') {
-    input
+    process.stdin
         .pipe(es.split())
         .pipe(Parser())
         .pipe(Aggregator(true))
@@ -274,7 +270,7 @@ if (params.command === 'import') {
 // Import data
 // ----------------------------------
 if (params.command === 'put') {
-    input
+    process.stdin
         .pipe(es.split())
         .pipe(Parser())
         .pipe(Aggregator(false))

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,6 +3,9 @@ var params = require('minimist')(process.argv.slice(2));
 var Dyno = require('../index.js');
 var queue = require('queue-async');
 var es = require('event-stream');
+var stream = require('stream');
+var zlib = require('zlib');
+var fs = require('fs');
 
 process.env.AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || 'fake';
 process.env.AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || 'fake';
@@ -60,32 +63,53 @@ if (!params.table && params.command !== 'tables') {
 
 var dyno = Dyno(params);
 
-// Transform stream to stringifies JSON objects and base64 encodes buffers
-var stringifier = es.through(function(record) {
-    var str = JSON.stringify(record, function(key, value) {
-        var val = this[key];
-        if (Buffer.isBuffer(val)) return 'base64:' + val.toString('base64');
-        return value;
-    });
+var input = params._[2] ?
+    fs.createReadStream(params._[2]).pipe(zlib.createGunzip()) : process.stdin;
 
-    this.emit('data', str + '\n');
-});
+// Transform stream to stringifies JSON objects and base64 encodes buffers
+function Stringifier() {
+    var stringifier = new stream.Transform({ highWaterMark: 100 });
+    stringifier._writableState.objectMode = true;
+    stringifier._readableState.objectMode = false;
+
+    stringifier._transform = function(record, enc, callback) {
+        var str = JSON.stringify(record, function(key, value) {
+            var val = this[key];
+            if (Buffer.isBuffer(val)) return 'base64:' + val.toString('base64');
+            return value;
+        });
+
+        this.push(str + '\n');
+        setImmediate(callback);
+    };
+
+    return stringifier;
+}
 
 // Transform stream parses JSON strings and base64 decodes into buffers
-var parser = es.through(function(record) {
-    if (!record) return;
+function Parser() {
+    var parser = new stream.Transform({ highWaterMark: 100 });
+    parser._writableState.objectMode = false;
+    parser._readableState.objectMode = true;
 
-    record = JSON.parse(record);
+    parser._transform = function(record, enc, callback) {
+        if (!record) return;
 
-    var val;
-    for (var key in record) {
-        val = record[key];
-        if (typeof val === 'string' && val.indexOf('base64:') === 0)
-            record[key] = new Buffer(val.split('base64:').pop(), 'base64');
-    }
+        record = JSON.parse(record);
 
-    this.emit('data', record);
-});
+        var val;
+        for (var key in record) {
+            val = record[key];
+            if (typeof val === 'string' && val.indexOf('base64:') === 0)
+                record[key] = new Buffer(val.split('base64:').pop(), 'base64');
+        }
+
+        this.push(record);
+        setImmediate(callback);
+    };
+
+    return parser;
+}
 
 // Remove unimportant table metadata from the description
 function cleanDescription(desc) {
@@ -111,7 +135,7 @@ function cleanDescription(desc) {
 
 function scan() {
     dyno.scan()
-        .pipe(stringifier)
+        .pipe(Stringifier())
         .pipe(process.stdout)
         .on('error', function(err) {
             console.error(err);
@@ -119,11 +143,47 @@ function scan() {
         });
 }
 
+// Transform stream that aggregates into sets of 25 objects
+function Aggregator(withTable) {
+    var firstline = !!withTable;
+
+    var aggregator = new stream.Transform({ objectMode: true, highWaterMark: 100 });
+    aggregator.records = [];
+
+    aggregator._transform = function(record, enc, callback) {
+        if (!record) return;
+        if (firstline) {
+            firstline = false;
+            this.push(record);
+        } else if (aggregator.records.length === 25) {
+            this.push(aggregator.records);
+            aggregator.records = [];
+        } else {
+            aggregator.records.push(record);
+        }
+        callback();
+    };
+
+    aggregator._flush = function(callback) {
+        if (aggregator.records.length) this.push(aggregator.records);
+        callback();
+    };
+
+    return aggregator;
+}
+
 function Importer(withTable) {
     var firstline = !!withTable;
     var q = queue(10);
 
-    var importer = es.through(function(data) {
+    var importer = stream.Transform({ objectMode: true, highWaterMark: 100 });
+    var queued = 0;
+
+    importer._transform = function(data, enc, callback) {
+        if (!data) return;
+        if (queued > 100)
+            setImmediate(importer._transform.bind(importer), data, enc, callback);
+
         if (firstline) {
             firstline = false;
             this.pause();
@@ -133,13 +193,20 @@ function Importer(withTable) {
                 this.resume();
             }.bind(this));
         } else {
-            q.defer(dyno.putItem, data);
+            queued++;
+            q.defer(function(next) {
+                dyno.putItems(data, function(err) {
+                    queued--;
+                    callback(err);
+                    next();
+                });
+            });
         }
-    });
+    };
 
-    q.awaitAll(function(err) {
-        if (err) importer.emit('error', err);
-    });
+    importer._flush = function(callback) {
+        q.awaitAll(callback);
+    };
 
     return importer;
 }
@@ -192,9 +259,10 @@ if (params.command === 'scan') scan();
 // Import table
 // ----------------------------------
 if (params.command === 'import') {
-    process.stdin
+    input
         .pipe(es.split())
-        .pipe(parser)
+        .pipe(Parser())
+        .pipe(Aggregator(true))
         .pipe(Importer(true))
         .on('error', function(err) {
             console.error(err);
@@ -206,9 +274,10 @@ if (params.command === 'import') {
 // Import data
 // ----------------------------------
 if (params.command === 'put') {
-    process.stdin
+    input
         .pipe(es.split())
-        .pipe(parser)
+        .pipe(Parser())
+        .pipe(Aggregator(false))
         .pipe(Importer(false))
         .on('error', function(err) {
             console.error(err);

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -217,6 +217,8 @@ test('cli: import table', function(assert) {
         });
     });
 
+    proc.stdout.pipe(process.stdout);
+    proc.stderr.pipe(process.stderr);
     proc.stdin.write(serialized);
     proc.stdin.end();
 });


### PR DESCRIPTION
- Uses batch writes during `dyno import` and `dyno put` calls.
- Manages memory better. Previous incarnation would `queue.defer()` too much work and run the process out of memory.
- Argument to specify a file path to feed into CLI write methods
