### PR TITLE
Allow configurable httpOptions

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -8,6 +8,7 @@ module.exports = function(c) {
 
     var opts = { region: c.region };
     if (c.endpoint && c.endpoint !== '') opts.endpoint = new AWS.Endpoint(c.endpoint);
+    if (c.httpOptions) opts.httpOptions = c.httpOptions;
 
     config.dynamo = new AWS.DynamoDB(opts);
     config.dynamo.config.update({

--- a/test/index.js
+++ b/test/index.js
@@ -6,3 +6,4 @@ require('./test.item');
 require('./test.table');
 require('./test.kinesis');
 require('./test.multi');
+require('./test.config');

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -1,7 +1,19 @@
 var test = require('tape');
 var Dyno = require('..');
+var https = require('https');
+var AWS = require('aws-sdk');
 
 test('isolates credentials', function(assert) {
+    process.env.AWS_ACCESS_KEY_ID = '';
+    process.env.AWS_SECRET_ACCESS_KEY = '';
+    process.env.AWS_SESSION_TOKEN = '';
+    AWS.config.update({
+        accessKeyId: 'default',
+        secretAccessKey: 'default',
+        sessionToken: 'default',
+        endpoint: 'default'
+    });
+
     var dynoA = Dyno({
         region: 'fake',
         accessKeyId: 'fake',
@@ -17,6 +29,18 @@ test('isolates credentials', function(assert) {
     if (dynoB.config.credentials) {
         assert.notEqual(dynoA.config.credentials.accessKeyId, dynoB.config.credentials.accessKeyId, 'isolated creds');
     }
-    assert.notOk(dynoB.config.credentials, 'no credentials assigned');
+    assert.deepEqual(dynoB.config.credentials, { accessKeyId: 'default', expireTime: null, expired: false, sessionToken: 'default' }, 'no credentials assigned');
+    assert.end();
+});
+
+test('allows httpOptions', function(assert) {
+    var dyno = Dyno({
+        region: 'us-east-1',
+        httpOptions: {
+            agent: new https.Agent({ maxSockets: 16 })
+        }
+    });
+
+    assert.equal(dyno.config.httpOptions.agent.maxSockets, 16, 'sets httpOptions');
     assert.end();
 });


### PR DESCRIPTION
Allows caller to pass httpOptions to dyno's [DynamoDB client constructor](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property)