### PR TITLE
Safer batch writes

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -115,18 +115,23 @@ module.exports = function(config) {
         });
 
         q.awaitAll(function(err, metas) {
-            if (!errors.lenth) return cb(null, null, _(metas).flatten());
+            if (!errors.length) return cb(null, null, _(metas).flatten());
 
             var error = errors.reduce(function(error, err) {
-                if (error) error.unprocessed = error.unprocessed.concat(err.unprocessed);
+                if (!error) {
+                    error = err;
+                    error.unprocessed = err.unprocessed || {};
+                }
                 else {
-                    error = new Error(err.message);
-                    error.unprocessed = err.unprocessed || [];
+                    _(err.unprocessed || {}).each(function(items, table) {
+                        error.unprocessed[table] = error.unprocessed[table] ?
+                            error.unprocessed[table].concat(items) : items;
+                    });
                 }
                 return error;
             }, null);
 
-            cb(err);
+            cb(error);
         });
     };
 
@@ -180,18 +185,23 @@ module.exports = function(config) {
         });
 
         q.awaitAll(function(err, metas) {
-            if (!errors.lenth) return cb(null, null, _(metas).flatten());
+            if (!errors.length) return cb(null, null, _(metas).flatten());
 
             var error = errors.reduce(function(error, err) {
-                if (error) error.unprocessed = error.unprocessed.concat(err.unprocessed);
+                if (!error) {
+                    error = err;
+                    error.unprocessed = err.unprocessed || {};
+                }
                 else {
-                    error = new Error(err.message);
-                    error.unprocessed = err.unprocessed || [];
+                    _(err.unprocessed || {}).each(function(items, table) {
+                        error.unprocessed[table] = error.unprocessed[table] ?
+                            error.unprocessed[table].concat(items) : items;
+                    });
                 }
                 return error;
             }, null);
 
-            cb(err);
+            cb(error);
         });
     };
 

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -99,22 +99,34 @@ module.exports = function(config) {
 
         if (chunk.length) chunks.push(chunk);
 
+        var errors = [];
+
         chunks.forEach(function(putRequests) {
             var p = _({}).extend(params, {
                 RequestItems: {}
             });
             p.RequestItems[table] = putRequests;
-            q.defer(function(callback) {
+            q.defer(function(next) {
                 dynamoRequest('batchWriteItem', p, function(err, res, meta) {
-                    if (err) return callback(err);
-                    callback(null, meta);
+                    if (err) errors.push(err);
+                    next(null, meta);
                 });
             });
         });
 
         q.awaitAll(function(err, metas) {
-            if (err) return cb(err);
-            cb(null, null, _(metas).flatten());
+            if (!errors.lenth) return cb(null, null, _(metas).flatten());
+
+            var error = errors.reduce(function(error, err) {
+                if (error) error.unprocessed = error.unprocessed.concat(err.unprocessed);
+                else {
+                    error = new Error(err.message);
+                    error.unprocessed = err.unprocessed || [];
+                }
+                return error;
+            }, null);
+
+            cb(err);
         });
     };
 
@@ -152,22 +164,34 @@ module.exports = function(config) {
 
         if (chunk.length) chunks.push(chunk);
 
+        var errors = [];
+
         chunks.forEach(function(deleteRequests) {
             var d = _({}).extend(params, {
                 RequestItems: {}
             });
             d.RequestItems[table] = deleteRequests;
-            q.defer(function(callback) {
+            q.defer(function(next) {
                 dynamoRequest('batchWriteItem', d, function(err, res, meta) {
-                    if (err) return callback(err);
-                    callback(null, meta);
+                    if (err) errors.push(err);
+                    next(null, meta);
                 });
             });
         });
 
         q.awaitAll(function(err, metas) {
-            if (err) return cb(err);
-            cb(null, null, _(metas).flatten());
+            if (!errors.lenth) return cb(null, null, _(metas).flatten());
+
+            var error = errors.reduce(function(error, err) {
+                if (error) error.unprocessed = error.unprocessed.concat(err.unprocessed);
+                else {
+                    error = new Error(err.message);
+                    error.unprocessed = err.unprocessed || [];
+                }
+                return error;
+            }, null);
+
+            cb(err);
         });
     };
 

--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -116,6 +116,9 @@ module.exports = function(config) {
                 }
 
                 if (err && !callback) return readable.emit('error', err);
+                if (err && err.code === 'ValidationException' && params.RequestItems) {
+                    err.unprocessed = params.RequestItems;
+                }
                 if (err) return callback(err);
 
                 var unprocessed = resp.UnprocessedKeys || resp.UnprocessedItems;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
-    "dynalite": "^0.13.2",
+    "dynalite": "^0.14.0",
     "istanbul": "^0.3.14",
     "jscs": "1.11.3",
     "jshint": "^2.6.3",

--- a/test/index.js
+++ b/test/index.js
@@ -1,10 +1,10 @@
 require('./setup')();
-require('./test.batch');
 require('./test.convertTypes');
 require('./test.cli');
 require('./test.item');
 require('./test.table');
 require('./test.kinesis');
-require('./test.multi');
+require('./test.batch');
 require('./test.config');
 require('./test.serialization');
+require('./test.multi');

--- a/test/test.batch.js
+++ b/test/test.batch.js
@@ -69,4 +69,5 @@ test('deleteItems', function(t) {
         });
     }
 });
+
 test('teardown', s.teardown);

--- a/test/test.batch.js
+++ b/test/test.batch.js
@@ -70,4 +70,61 @@ test('deleteItems', function(t) {
     }
 });
 
+test('putItems: invalid item in the array', function(t) {
+    var items = randomItems(25);
+    items.push({
+        hash: 'failure',
+        span: 7
+    });
+    items = items.concat(randomItems(10));
+
+    dyno.putItems(items, function(err, data) {
+        t.ok(err, 'expected error');
+        t.equal(err.code, 'ValidationException', 'expected error code');
+
+        var unprocessed = err.unprocessed[Object.keys(err.unprocessed)[0]];
+        t.equal(unprocessed.length, 11, 'unprocessed records returned');
+
+        dyno.scan(function(err, items) {
+            t.ifError(err, 'scan success');
+            t.equal(items.length, 25, '25/36 objects written');
+            t.end();
+        });
+    });
+});
+
+test('deleteItems: one invalid key', function(t) {
+    var items = randomItems(36);
+    dyno.putItems(items, function(err) {
+        if (err) throw err;
+
+        var keys = items.map(function(item) {
+            return {
+                id: item.id,
+                range: item.range
+            };
+        });
+
+        keys.pop();
+        keys.push({
+            hash: 'failure',
+            span: 7
+        });
+
+        dyno.deleteItems(keys, function(err, data) {
+            t.ok(err, 'expected error');
+            t.equal(err.code, 'ValidationException', 'expected error code');
+
+            var unprocessed = err.unprocessed[Object.keys(err.unprocessed)[0]];
+            t.equal(unprocessed.length, 11, 'unprocessed records returned');
+
+            dyno.scan(function(err, items) {
+                t.ifError(err, 'scan success');
+                t.equal(items.length, 11, '25/36 objects deleted');
+                t.end();
+            });
+        });
+    });
+});
+
 test('teardown', s.teardown);


### PR DESCRIPTION
Refs #80 

This adds aggregation of unprocessed items across multiple batch requests that a single `dyno.putItems` or `dyno.deleteItems` request might make. The scenario that is tested:

- you have 25 valid records, then one invalid one, then 10 more valid ones in an array
- you `dyno.putItems`
- dyno completes a successful `batchWriteItems` request for the first 25 items, but the second request fails validation -- this results in no writes.
- your `dyno.putItems` request returns an error, with `err.unprocessed` containing the 11 keys (including your invalid one) that were not written

Similar test scenario for `dyno.deleteItems`. Note that this is only tested for the _case of user error_, where you have handed dyno some invalid records. I don't have a good way to simulate a batch write request that say, makes 12 requests successfully, then fails due to networking problems, resulting in an additional 13 unprocessed items.

> If any requested operations fail because the table's provisioned throughput is exceeded or an internal processing failure occurs, the failed operations are returned in the UnprocessedItems response parameter

Dynalite will never let me exceed provisioned throughput to test this. 

cc @emilymcafee @willwhite 
