### PR TITLE
Add support for document types (List and Map), Boolean, and Null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,11 @@
 ## upcoming
 
+- Add support for [document types (List and Map)][1], [Boolean][2], and [Null][3]
+- Native JavaScript arrays will now transform into lists instead of sets
+- Add `dyno.createSet()`, which constructs sets (of number, string, or binary
+  type) that transform to the DynamoDB wire format correctly.
+- Drop support for using a wire-formatted object as input.
+
+[1]:http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModel.DataTypes.Document
+[2]:http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModel.DataTypes.Boolean
+[3]:http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModel.DataTypes.Null

--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ dyno local table my-table
 
 ##### Scan a table:
 
-Outputs line delimited JSON for every item in the table.
+Outputs line delimited JSON in wire-format for every item in the table.
 
 ```
 dyno local scan my-table
 
-{"id":"0.9410678697749972","collection":"somethign:0","attr":"moredata 64"}
-{"id":"0.9417226337827742","collection":"somethign:0","attr":"moredata 24"}
-{"id":"0.9447696127463132","collection":"somethign:0","attr":"moredata 48"}
-{"id":"0.9472108569461852","collection":"somethign:0","attr":"moredata 84"}
+{"id":{"N":"0.9410678697749972"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 64"}}
+{"id":{"N":"0.9417226337827742"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 24"}}
+{"id":{"N":"0.9447696127463132"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 48"}}
+{"id":{"N":"0.9472108569461852"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 84"}}
 ....
 
 ```
@@ -94,10 +94,10 @@ Outputs the table schema then does a scan (like above)
 dyno local export my-table
 
 {"AttributeDefinitions":[{"AttributeName":"collection","AttributeType":"S"},...]}
-{"id":"0.9410678697749972","collection":"somethign:0","attr":"moredata 64"}
-{"id":"0.9417226337827742","collection":"somethign:0","attr":"moredata 24"}
-{"id":"0.9447696127463132","collection":"somethign:0","attr":"moredata 48"}
-{"id":"0.9472108569461852","collection":"somethign:0","attr":"moredata 84"}
+{"id":{"N":"0.9410678697749972"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 64"}}
+{"id":{"N":"0.9417226337827742"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 24"}}
+{"id":{"N":"0.9447696127463132"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 48"}}
+{"id":{"N":"0.9472108569461852"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 84"}}
 ....
 
 ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ dyno us-west-1 scan my-table | dyno local put my-table-copy
 ##### Setup
 
 ```
-var dyno = module.exports.dyno = require('dyno')({
+var dyno = require('dyno')({
     accessKeyId: 'XXX',
     secretAccessKey: 'XXX',
     region: 'us-east-1',
@@ -240,6 +240,21 @@ dyno.query(query, {start: next, pages: 1}, function(err, resp, metas) {
     ...
 });
 ```
+
+#### Type Utilties
+
+##### `Dyno.createSet(array, type)`
+
+Turn a native JavaScript array into an explicit set. The type is preserved when
+converting to the DynamoDB wire format.
+
+##### `Dyno.toDynamoTypes(nativeObj)`
+
+Convert a native JavaScript object into the DynamoDB wire format.
+
+##### `Dyno.typesFromDynamo(writeObj)`
+
+Convert an object in DynamoDB wire format to native JavaScript objects.
 
 #### multi + kinesisConfig
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -69,11 +69,7 @@ function Stringifier() {
     stringifier._readableState.objectMode = false;
 
     stringifier._transform = function(record, enc, callback) {
-        var str = JSON.stringify(record, function(key, value) {
-            var val = this[key];
-            if (Buffer.isBuffer(val)) return 'base64:' + val.toString('base64');
-            return value;
-        });
+        var str = Dyno.serialize(record);
 
         this.push(str + '\n');
         setImmediate(callback);
@@ -91,14 +87,7 @@ function Parser() {
     parser._transform = function(record, enc, callback) {
         if (!record) return;
 
-        record = JSON.parse(record);
-
-        var val;
-        for (var key in record) {
-            val = record[key];
-            if (typeof val === 'string' && val.indexOf('base64:') === 0)
-                record[key] = new Buffer(val.split('base64:').pop(), 'base64');
-        }
+        record = Dyno.deserialize(record);
 
         this.push(record);
         setImmediate(callback);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ function Dyno(c) {
     _(dyno).extend(require('./lib/table')(config));
     _(dyno).extend(require('./lib/batch')(config));
     _(dyno).extend(require('./lib/describe')(config));
-    _(dyno).extend(require('./lib/types'));
     return dyno;
 }
 
@@ -27,6 +26,11 @@ Dyno.multi = function(readConfig, writeConfig) {
 
     return require('./lib/multi')(read, write);
 };
+
+var types = require('./lib/types');
+Dyno.createSet = types.createSet;
+Dyno.toDynamoTypes = types.toDynamoTypes;
+Dyno.typesFromDynamo = types.typesFromDynamo;
 
 function badconfig(message) {
     var err = new Error(message);

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ function Dyno(c) {
     _(dyno).extend(require('./lib/table')(config));
     _(dyno).extend(require('./lib/batch')(config));
     _(dyno).extend(require('./lib/describe')(config));
-    dyno.createSet = require('./lib/types').createSet;
+    _(dyno).extend(require('./lib/types'));
     return dyno;
 }
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ function Dyno(c) {
     _(dyno).extend(require('./lib/table')(config));
     _(dyno).extend(require('./lib/batch')(config));
     _(dyno).extend(require('./lib/describe')(config));
+    dyno.createSet = require('./lib/types').createSet;
     return dyno;
 }
 

--- a/index.js
+++ b/index.js
@@ -28,9 +28,55 @@ Dyno.multi = function(readConfig, writeConfig) {
 };
 
 var types = require('./lib/types');
-Dyno.createSet = types.createSet;
-Dyno.toDynamoTypes = types.toDynamoTypes;
-Dyno.typesFromDynamo = types.typesFromDynamo;
+Dyno.createSet = types.createSet.bind(types);
+
+Dyno.serialize = function(item) {
+    function replacer(key, value) {
+        if (Buffer.isBuffer(this[key])) return this[key].toString('base64');
+
+        if (this[key].BS &&
+            Array.isArray(this[key].BS) &&
+            _(this[key].BS).every(function(buf) {
+                return Buffer.isBuffer(buf);
+            }))
+        {
+            return {
+                BS: this[key].BS.map(function(buf) {
+                    return buf.toString('base64');
+                })
+            };
+        }
+
+        return value;
+    }
+
+    return JSON.stringify(types.toDynamoTypes(item), replacer);
+};
+
+Dyno.deserialize = function(str) {
+    function reviver(key, value) {
+        if (typeof value === 'object' && value.B && typeof value.B === 'string') {
+            return { B: new Buffer(value.B, 'base64') };
+        }
+
+        if (typeof value === 'object' &&
+            value.BS &&
+            Array.isArray(value.BS))
+        {
+            return {
+                BS: value.BS.map(function(s) {
+                    return new Buffer(s, 'base64');
+                })
+            };
+        }
+
+        return value;
+    }
+
+    str = JSON.parse(str, reviver);
+    str = types.typesFromDynamo(str);
+    return str[0];
+};
 
 function badconfig(message) {
     var err = new Error(message);

--- a/lib/kinesis.js
+++ b/lib/kinesis.js
@@ -44,9 +44,7 @@ module.exports = function(requestType, config) {
         if (action === 'deleteItem') key = request.Key;
         if (action === 'putItem') {
             config.kinesisConfig.key.forEach(function(keyFieldName) {
-                key[keyFieldName] = types.typesFromDynamo(
-                    request.Item[keyFieldName]
-                )[0];
+                key[keyFieldName] = request.Item[keyFieldName];
             });
         }
 

--- a/lib/types.js
+++ b/lib/types.js
@@ -2,81 +2,48 @@ var util = require('util');
 var _ = require('underscore');
 var types = module.exports = {};
 
+var DynamoDBDatatype = require('dynamodb-doc/lib/datatypes').DynamoDBDatatype;
+var datatypes = new DynamoDBDatatype();
+
 //  Convert to Dynamo's Object notation, unless it is already.
 types.toDynamoTypes = function(obj) {
-    obj = _(obj).clone();
+    var attributeValueMap = {};
     if (Array.isArray(obj)) return obj.map(types.toDynamoTypes);
-
-    function pushString(v) { this.push(v.toString()); }
-    function pushVal(v) { this.push(v); }
-
-    for (var key in obj) {
-        var val = obj[key];
-        if (val === null) continue;
-        if (typeof val === 'object' && !Array.isArray(val) && !Buffer.isBuffer(val)) {
-            if (['N', 'S', 'B', 'NS', 'SS', 'BS'].indexOf(Object.keys(val)[0]) !== -1) {
-                continue;
-            } else {
-                throw new Error('Unknown attribute ' + val);
-            }
-        }
-
-        if (typeof val === 'number') {
-            obj[key] = { N: val.toString() };
-        } else if (Array.isArray(val)) {
-            var arr;
-            if (typeof val[0] === 'number') {
-                obj[key] = { NS: [] };
-                arr = obj[key].NS;
-                val.forEach(pushString.bind(arr));
-            } else if (Buffer.isBuffer(val[0])) {
-                obj[key] = { BS: [] };
-                arr = obj[key].BS;
-                val.forEach(pushVal.bind(arr));
-            } else {
-                obj[key] = { SS: [] };
-                arr = obj[key].SS;
-                val.forEach(pushString.bind(arr));
-            }
-        } else if (Buffer.isBuffer(val)) {
-            obj[key] = { B: val };
-        } else {
-            obj[key] = { S: val.toString() };
-        }
+    if (typeof obj === 'string') return obj;
+    for (var attr in obj) {
+        var value = obj[attr];
+        attributeValueMap[attr] = datatypes.formatDataType(value);
     }
-    return obj;
+    return attributeValueMap;
 };
 
 // Convert types in the Dynamo request to normal objects.
 types.typesFromDynamo = function(items) {
     if (!items) return;
     if (!util.isArray(items)) items = [items];
-
-    return _(items).map(function(item) {
-        _(item).each(function(v, k) {
-            if (v.N) {
-                item[k] = parseFloat(v.N);
-            } else if (v.S) {
-                item[k] = v.S;
-            } else if (v.NS) {
-                item[k] = _(v.NS).map(function(i) {
-                    return parseFloat(i);
-                });
-            } else if (v.SS) {
-                item[k] = _(v.SS).map(function(i) {
-                    return i;
-                });
-            } else if (v.B) {
-                item[k] = v.B;
-            } else if (v.BS) {
-                item[k] = _(v.BS).map(function(i) {
-                    return new Buffer(i);
-                });
-            }
-        });
-        return item;
-    });
+    return formatItems(items);
 };
+
+function formatAttrValOutput(item) {
+    var attrList = {};
+    for (var attribute in item) {
+        var keys = Object.keys(item[attribute]);
+        var key = keys[0];
+        var value = item[attribute][key];
+
+        value = datatypes.formatWireType(key, value);
+        attrList[attribute] = value;
+    }
+
+    return attrList;
+}
+
+function formatItems(items) {
+    for (var index in items) {
+        items[index] = formatAttrValOutput(items[index]);
+    }
+    return items;
+}
 
 function actionValue(attrs, action) {
     action = action.toUpperCase();

--- a/lib/types.js
+++ b/lib/types.js
@@ -5,6 +5,8 @@ var types = module.exports = {};
 var DynamoDBDatatype = require('dynamodb-doc/lib/datatypes').DynamoDBDatatype;
 var datatypes = new DynamoDBDatatype();
 
+types.createSet = datatypes.createSet;
+
 //  Convert to Dynamo's Object notation, unless it is already.
 types.toDynamoTypes = function(obj) {
     var attributeValueMap = {};

--- a/lib/types.js
+++ b/lib/types.js
@@ -7,7 +7,7 @@ var datatypes = new DynamoDBDatatype();
 
 types.createSet = datatypes.createSet;
 
-//  Convert to Dynamo's Object notation, unless it is already.
+//  Convert to Dynamo's Object notation.
 types.toDynamoTypes = function(obj) {
     var attributeValueMap = {};
     if (Array.isArray(obj)) return obj.map(types.toDynamoTypes);
@@ -59,6 +59,9 @@ function actionValue(attrs, action) {
     } else {
         for (var a in attrs) {
             attrs[a] = {Action: action, Value: attrs[a]};
+
+            // Exception for null values inside `delete` statements.
+            // Allows this to mean delete: {delete: {foo: null, bar: null}}
             if (action === 'DELETE' && attrs[a].Value.NULL) delete attrs[a].Value;
         }
     }

--- a/lib/types.js
+++ b/lib/types.js
@@ -59,7 +59,7 @@ function actionValue(attrs, action) {
     } else {
         for (var a in attrs) {
             attrs[a] = {Action: action, Value: attrs[a]};
-            if (attrs[a].Value === null) delete attrs[a].Value;
+            if (action === 'DELETE' && attrs[a].Value.NULL) delete attrs[a].Value;
         }
     }
     return attrs;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "aws-sdk": "2.1.16",
     "big.js": "^2.5.1",
+    "dynamodb-doc": "^1.0.0",
     "event-stream": "^3.1.5",
     "minimist": "^1.1.0",
     "queue-async": "~1.0.7",

--- a/test/index.js
+++ b/test/index.js
@@ -7,3 +7,4 @@ require('./test.table');
 require('./test.kinesis');
 require('./test.multi');
 require('./test.config');
+require('./test.serialization');

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -7,6 +7,7 @@ var fixtures = require('./fixtures');
 var setup = require('./setup')();
 var test = setup.test;
 var dyno = setup.dyno;
+var Dyno = require('..');
 
 // use --verbose to print cli output to terminal during the test run
 var verbose = process.argv.indexOf('--verbose') > -1;
@@ -150,7 +151,7 @@ test('cli: export table', function(assert) {
             assert.deepEqual(table, cleanedTable, 'printed cleaned table definition to stdout');
 
             var expectedRecords = records.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             var intersection = _.intersection(expectedRecords, results);
@@ -177,7 +178,7 @@ test('cli: scan table', function(assert) {
             var results = stdout.trim().split('\n');
 
             var expectedRecords = records.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             var intersection = _.intersection(expectedRecords, results);
@@ -192,7 +193,7 @@ test('cli: setup', setup.setup());
 test('cli: import table', function(assert) {
     var records = fixtures.randomItems(10);
     var serialized = _.union([cleanedTable], records).map(function(line) {
-        return JSON.stringify(line);
+        return Dyno.serialize(line);
     }).join('\n');
 
     var proc = runCli(['import', 'local/' + setup.tableName], function(err, stdout, stderr) {
@@ -204,11 +205,11 @@ test('cli: import table', function(assert) {
             }
 
             var expectedRecords = records.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             items = items.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             var intersection = _.intersection(expectedRecords, items);
@@ -229,7 +230,7 @@ test('cli: setup table', setup.setupTable);
 test('cli: import data', function(assert) {
     var records = fixtures.randomItems(10);
     var serialized = records.map(function(line) {
-        return JSON.stringify(line);
+        return Dyno.serialize(line);
     }).join('\n');
 
     var proc = runCli(['put', 'local/' + setup.tableName], function(err, stdout, stderr) {
@@ -241,11 +242,11 @@ test('cli: import data', function(assert) {
             }
 
             var expectedRecords = records.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             items = items.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             var intersection = _.intersection(expectedRecords, items);
@@ -279,7 +280,7 @@ test('cli: export complicated record', function(assert) {
 
         runCli(['scan', 'local/' + setup.tableName], function(err, stdout, stderr) {
             assert.ifError(err, 'cli success');
-            assert.equal(stdout.trim(), '{"id":"id:1","range":1,"buffer":"base64:aGVsbG8gd29ybGQh","array":[0,1,2],"newline":"0\\n1"}', 'printed record to stdout');
+            assert.equal(stdout.trim(), '{"id":{"S":"id:1"},"range":{"N":"1"},"buffer":{"B":"aGVsbG8gd29ybGQh"},"array":{"L":[{"N":"0"},{"N":"1"},{"N":"2"}]},"newline":{"S":"0\\n1"}}', 'printed record to stdout');
             assert.end();
         });
     });
@@ -312,7 +313,7 @@ test('cli: import complicated record', function(assert) {
         });
     });
 
-    proc.stdin.write('{"id":"id:1","range":1,"buffer":"base64:aGVsbG8gd29ybGQh","array":[0,1,2],"newline":"0\\n1"}');
+    proc.stdin.write('{"id":{"S":"id:1"},"range":{"N":"1"},"buffer":{"B":"aGVsbG8gd29ybGQh"},"array":{"L":[{"N":"0"},{"N":"1"},{"N":"2"}]},"newline":{"S":"0\\n1"}}');
     proc.stdin.end();
 });
 test('cli: deleteTable', setup.deleteTable);

--- a/test/test.convertTypes.js
+++ b/test/test.convertTypes.js
@@ -153,3 +153,39 @@ test('convert update actions - add and delete', function(t) {
     t.deepEqual(item, { counter: { Action: 'ADD', Value: { N: '5' } }, newset: { Action: 'DELETE', Value: { SS: ['a'] } } });
     t.end();
 });
+
+test('typesFromDynamo - undefined', function(t) {
+    var items;
+
+    item = types.typesFromDynamo(items);
+    t.deepEqual(item, undefined);
+    t.end();
+});
+
+test('typesFromDynamo - single item', function(t) {
+    var items = {id: { S: 'id:2' }};
+
+    item = types.typesFromDynamo(items);
+    t.deepEqual(item, [{id: 'id:2'}]);
+    t.end();
+});
+
+test('typesFromDynamo - single item, no property name', function(t) {
+    var items = { S: 'id:2' };
+
+    item = types.typesFromDynamo(items);
+    t.deepEqual(item, [{ S: 'id:2' }]);
+    t.end();
+});
+
+test('typesFromDynamo - item', function(t) {
+    var items = [{
+        id: { S: 'id:2' },
+        range: { N: '2' },
+        buffer: { B: new Buffer('hi') }
+    }];
+
+    item = types.typesFromDynamo(items);
+    t.deepEqual(item, [{buffer: new Buffer('hi'), id: 'id:2', range: 2}]);
+    t.end();
+});

--- a/test/test.convertTypes.js
+++ b/test/test.convertTypes.js
@@ -17,6 +17,14 @@ test('convert booleans', function(t) {
     t.end();
 });
 
+test('convert null', function(t) {
+    var item = {n: null};
+
+    item = types.toDynamoTypes(item);
+    t.deepEqual(item, {n: {NULL: true}});
+    t.end();
+});
+
 test('convert numbers', function(t) {
     var item = {id: 6};
 
@@ -75,11 +83,118 @@ test('convert sets multiple items', function(t) {
     t.end();
 });
 
-test('convert multiple types', function(t) {
-    var item = {string: 'a', number: 6, set: types.createSet([1, 2], 'N'), set2: types.createSet(['a', 'b'], 'S')};
+test('convert lists - numbers', function(t) {
+    var item = {list: [6, 5, 4, 3, 2, 1]};
 
     item = types.toDynamoTypes(item);
-    t.deepEqual(item, {string: {S:'a'}, number: {N:'6'}, set:{NS:['1', '2']}, set2: {SS:['a', 'b']}});
+    t.deepEqual(item, { list: { L: [{ N: '6' }, { N: '5' }, { N: '4' }, { N: '3' }, { N: '2' }, { N: '1' }] } });
+    t.end();
+});
+
+test('convert lists - strings', function(t) {
+    var item = {list: ['foo', 'bar']};
+
+    item = types.toDynamoTypes(item);
+    t.deepEqual(item, { list: { L: [{ S: 'foo' }, { S: 'bar' }] } });
+    t.end();
+});
+
+test('convert lists - multiple types', function(t) {
+    var item = {list: [1, 'foo', null, false]};
+
+    item = types.toDynamoTypes(item);
+    t.deepEqual(item, { list: { L: [{ N: '1' }, { S: 'foo' }, { NULL: true }, { BOOL: false }] } });
+    t.end();
+});
+
+test('convert maps', function(t) {
+    var item = {map: {
+        date: 12345,
+        foo: 'bar',
+        valid: true
+    }};
+
+    item = types.toDynamoTypes(item);
+    t.deepEqual(item, { map: { M: { date: { N: '12345' }, foo: { S: 'bar' }, valid: { BOOL: true } } } });
+    t.end();
+});
+
+test('convert multiple types', function(t) {
+    var item = {
+        string: 'a',
+        number: 6,
+        set: types.createSet([1, 2], 'N'),
+        set2: types.createSet(['a', 'b'], 'S'),
+        list: ['a', 2, null, true, false, {foo: 'bar'}],
+        bool: true,
+        bool2: false,
+        map: {
+            string: 'a',
+            number: 6,
+            set: types.createSet([1, 2], 'N'),
+            set2: types.createSet(['a', 'b'], 'S'),
+            list: ['a', 2, null, true, false, {foo: 'bar'}],
+            bool: true,
+            bool2: false,
+            nested: {
+                string: 'a',
+                number: 6,
+                set: types.createSet([1, 2], 'N'),
+                set2: types.createSet(['a', 'b'], 'S'),
+                list: ['a', 2, null, true, false, {foo: 'bar'}],
+                bool: true,
+                bool2: false
+            }
+        }
+    };
+
+    item = types.toDynamoTypes(item);
+    t.deepEqual(item, { string: { S: 'a' },
+        number: { N: '6' },
+        set: { NS: ['1', '2'] },
+        set2: { SS: ['a', 'b'] },
+        list:
+         { L:
+            [{ S: 'a' },
+              { N: '2' },
+              { NULL: true },
+              { BOOL: true },
+              { BOOL: false },
+              { M: { foo: { S: 'bar' } } }] },
+        bool: { BOOL: true },
+        bool2: { BOOL: false },
+        map:
+         { M:
+            { string: { S: 'a' },
+              number: { N: '6' },
+              set: { NS: ['1', '2'] },
+              set2: { SS: ['a', 'b'] },
+              list:
+               { L:
+                  [{ S: 'a' },
+                    { N: '2' },
+                    { NULL: true },
+                    { BOOL: true },
+                    { BOOL: false },
+                    { M: { foo: { S: 'bar' } } }] },
+              bool: { BOOL: true },
+              bool2: { BOOL: false },
+              nested:
+               { M:
+                  { string: { S: 'a' },
+                    number: { N: '6' },
+                    set: { NS: ['1', '2'] },
+                    set2: { SS: ['a', 'b'] },
+                    list:
+                     { L:
+                        [{ S: 'a' },
+                          { N: '2' },
+                          { NULL: true },
+                          { BOOL: true },
+                          { BOOL: false },
+                          { M: { foo: { S: 'bar' } } }] },
+                    bool: { BOOL: true },
+                    bool2: { BOOL: false } } } } } });
     t.end();
 });
 

--- a/test/test.convertTypes.js
+++ b/test/test.convertTypes.js
@@ -223,7 +223,7 @@ test('convert update actions - NS', function(t) {
 });
 
 test('convert update actions - delete from SS', function(t) {
-    var item = {delete: {newset: ['a']}};
+    var item = {delete: {newset: types.createSet(['a'], 'S')}};
 
     item = types.toAttributeUpdates(item);
     t.deepEqual(item, { newset: { Action: 'DELETE', Value: { SS: ['a'] } } });
@@ -231,7 +231,7 @@ test('convert update actions - delete from SS', function(t) {
 });
 
 test('convert update actions - add to SS', function(t) {
-    var item = {add: {newset: ['a']}};
+    var item = {add: {newset: types.createSet(['a'], 'S')}};
 
     item = types.toAttributeUpdates(item);
     t.deepEqual(item, { newset: { Action: 'ADD', Value: { SS: ['a'] } } });
@@ -261,7 +261,7 @@ test('convert update actions - delete with null', function(t) {
 test('convert update actions - add and delete', function(t) {
     var item = {
         add: {newset: 'a', counter: 5},
-        delete: {newset: ['a']}
+        delete: {newset: types.createSet(['a'], 'S')}
     };
 
     item = types.toAttributeUpdates(item);

--- a/test/test.convertTypes.js
+++ b/test/test.convertTypes.js
@@ -182,3 +182,13 @@ test('typesFromDynamo - item', function(t) {
     t.deepEqual(item, [{buffer: new Buffer('hi'), id: 'id:2', list: [6, 5, 4, 3, 2, 1], range: 2}]);
     t.end();
 });
+
+test('typesFromDynamo - set', function(t) {
+    var items = [{
+        set: {NS: ['6', '5', '4', '3', '2', '1']}
+    }];
+
+    item = types.typesFromDynamo(items);
+    t.deepEqual(item[0].set.contents, types.createSet([6, 5, 4, 3, 2, 1], 'N').contents);
+    t.end();
+});

--- a/test/test.convertTypes.js
+++ b/test/test.convertTypes.js
@@ -170,14 +170,6 @@ test('typesFromDynamo - single item', function(t) {
     t.end();
 });
 
-test('typesFromDynamo - single item, no property name', function(t) {
-    var items = { S: 'id:2' };
-
-    item = types.typesFromDynamo(items);
-    t.deepEqual(item, [{ S: 'id:2' }]);
-    t.end();
-});
-
 test('typesFromDynamo - item', function(t) {
     var items = [{
         id: { S: 'id:2' },

--- a/test/test.convertTypes.js
+++ b/test/test.convertTypes.js
@@ -43,7 +43,7 @@ test('convert binary', function(t) {
 });
 
 test('convert sets - strings', function(t) {
-    var item = {set: ['a']};
+    var item = {set: types.createSet(['a'], 'S')};
 
     item = types.toDynamoTypes(item);
     t.deepEqual(item, {set: {SS: ['a']}});
@@ -51,7 +51,7 @@ test('convert sets - strings', function(t) {
 });
 
 test('convert sets - numbers', function(t) {
-    var item = {set: [6]};
+    var item = {set: types.createSet([6], 'N')};
 
     item = types.toDynamoTypes(item);
     t.deepEqual(item, {set: {NS: ['6']}});
@@ -60,7 +60,7 @@ test('convert sets - numbers', function(t) {
 
 test('convert sets - binary', function(t) {
     var buffy = new Buffer('hi');
-    var item = { set: [buffy] };
+    var item = { set: types.createSet([buffy], 'B') };
 
     item = types.toDynamoTypes(item);
     t.deepEqual(item, {set: { BS: [buffy] }});
@@ -68,15 +68,15 @@ test('convert sets - binary', function(t) {
 });
 
 test('convert sets multiple items', function(t) {
-    var item = {set: [6, 5, 4, 3, 2, 1]};
+    var item = {set: types.createSet([6, 5, 4, 3, 2, 1], 'N')};
 
     item = types.toDynamoTypes(item);
-    t.deepEqual(item, {set: {NS: ['6', '5', '4', '3', '2', '1']}});
+    t.deepEqual(item, {set: {NS: ['1', '2', '3', '4', '5', '6']}});
     t.end();
 });
 
 test('convert multiple types', function(t) {
-    var item = {string: 'a', number: 6, set:[1, 2], set2: ['a', 'b']};
+    var item = {string: 'a', number: 6, set: types.createSet([1, 2], 'N'), set2: types.createSet(['a', 'b'], 'S')};
 
     item = types.toDynamoTypes(item);
     t.deepEqual(item, {string: {S:'a'}, number: {N:'6'}, set:{NS:['1', '2']}, set2: {SS:['a', 'b']}});
@@ -100,7 +100,7 @@ test('convert update actions - delete', function(t) {
 });
 
 test('convert update actions - NS', function(t) {
-    var item = {add:{set: [1, 2]}};
+    var item = {add:{set: types.createSet([1, 2], 'N')}};
 
     item = types.toAttributeUpdates(item);
     t.deepEqual(item, {set: {Action: 'ADD', Value:{NS: ['1', '2']}}});

--- a/test/test.convertTypes.js
+++ b/test/test.convertTypes.js
@@ -182,10 +182,11 @@ test('typesFromDynamo - item', function(t) {
     var items = [{
         id: { S: 'id:2' },
         range: { N: '2' },
-        buffer: { B: new Buffer('hi') }
+        buffer: { B: new Buffer('hi') },
+        list: {L: [{N: '6'}, {N: '5'}, {N: '4'}, {N: '3'}, {N: '2'}, {N: '1'}]}
     }];
 
     item = types.typesFromDynamo(items);
-    t.deepEqual(item, [{buffer: new Buffer('hi'), id: 'id:2', range: 2}]);
+    t.deepEqual(item, [{buffer: new Buffer('hi'), id: 'id:2', list: [6, 5, 4, 3, 2, 1], range: 2}]);
     t.end();
 });

--- a/test/test.convertTypes.js
+++ b/test/test.convertTypes.js
@@ -9,6 +9,14 @@ test('convert strings', function(t) {
     t.end();
 });
 
+test('convert booleans', function(t) {
+    var item = {bool1: true, bool2: false };
+
+    item = types.toDynamoTypes(item);
+    t.deepEqual(item, {bool1: {BOOL: true}, bool2: {BOOL: false}});
+    t.end();
+});
+
 test('convert numbers', function(t) {
     var item = {id: 6};
 

--- a/test/test.convertTypes.js
+++ b/test/test.convertTypes.js
@@ -7,7 +7,6 @@ test('convert strings', function(t) {
     item = types.toDynamoTypes(item);
     t.deepEqual(item, {id: {S:'yo'}});
     t.end();
-
 });
 
 test('convert numbers', function(t) {
@@ -15,6 +14,14 @@ test('convert numbers', function(t) {
 
     item = types.toDynamoTypes(item);
     t.deepEqual(item, {id: {N: '6'}});
+    t.end();
+});
+
+test('recursive strings', function(t) {
+    var item = 'yo';
+
+    item = types.toDynamoTypes(item);
+    t.deepEqual(item, 'yo');
     t.end();
 });
 

--- a/test/test.item.js
+++ b/test/test.item.js
@@ -72,7 +72,7 @@ test('conditional put', function(t) {
 
         var options = {
             expected:{
-                range:{NE: [{ N: item.range.toString() }]}
+                range:{NE: [item.range]}
             }
         };
         dyno.putItem(item, options, expectFailure);

--- a/test/test.item.js
+++ b/test/test.item.js
@@ -391,15 +391,16 @@ test('update Item ', function(t) {
 test('update Item ', function(t) {
 
     var key = { id: 'yo', range: 5 };
-    var actions = {put: { newset: ['a', 'b'] }, delete: ['newkey'], add: {counter: 1}};
+    var actions = {put: { newset: dyno.createSet(['a', 'b'], 'S') }, delete: ['newkey'], add: {counter: 1}};
     var d = dyno.updateItem(key, actions, function(err, resp) {
         t.notOk(err);
         dyno.getItem(key, function(err, data) {
             t.notOk(err, 'no error');
+            data.newset = data.newset.contents;
             t.deepEqual(data, {
                 id: 'yo',
                 range: 5,
-                newset: ['a', 'b'],
+                newset: dyno.createSet(['a', 'b'], 'S').contents,
                 counter: 1
             }, 'item was really updated');
             t.end();
@@ -410,15 +411,16 @@ test('update Item ', function(t) {
 test('update Item - delete from set', function(t) {
 
     var key = { id: 'yo', range: 5 };
-    var actions = {delete: {newset: ['a'], counter:null}};
+    var actions = {delete: {newset: dyno.createSet(['a'], 'S'), counter:null}};
     var d = dyno.updateItem(key, actions, function(err, resp) {
         t.notOk(err);
         dyno.getItem(key, function(err, data) {
             t.notOk(err, 'no error');
+            data.newset = data.newset.contents;
             t.deepEqual(data, {
                 id: 'yo',
                 range: 5,
-                newset: ['b']
+                newset: dyno.createSet(['b'], 'S').contents
             }, 'item was really updated');
             t.end();
         });

--- a/test/test.item.js
+++ b/test/test.item.js
@@ -1,3 +1,4 @@
+var Dyno = require('../');
 var s = require('./setup')();
 var test = s.test;
 var es = require('event-stream');
@@ -391,7 +392,7 @@ test('update Item ', function(t) {
 test('update Item ', function(t) {
 
     var key = { id: 'yo', range: 5 };
-    var actions = {put: { newset: dyno.createSet(['a', 'b'], 'S') }, delete: ['newkey'], add: {counter: 1}};
+    var actions = {put: { newset: Dyno.createSet(['a', 'b'], 'S') }, delete: ['newkey'], add: {counter: 1}};
     var d = dyno.updateItem(key, actions, function(err, resp) {
         t.notOk(err);
         dyno.getItem(key, function(err, data) {
@@ -400,7 +401,7 @@ test('update Item ', function(t) {
             t.deepEqual(data, {
                 id: 'yo',
                 range: 5,
-                newset: dyno.createSet(['a', 'b'], 'S').contents,
+                newset: Dyno.createSet(['a', 'b'], 'S').contents,
                 counter: 1
             }, 'item was really updated');
             t.end();
@@ -411,7 +412,7 @@ test('update Item ', function(t) {
 test('update Item - delete from set', function(t) {
 
     var key = { id: 'yo', range: 5 };
-    var actions = {delete: {newset: dyno.createSet(['a'], 'S'), counter:null}};
+    var actions = {delete: {newset: Dyno.createSet(['a'], 'S'), counter:null}};
     var d = dyno.updateItem(key, actions, function(err, resp) {
         t.notOk(err);
         dyno.getItem(key, function(err, data) {
@@ -420,7 +421,7 @@ test('update Item - delete from set', function(t) {
             t.deepEqual(data, {
                 id: 'yo',
                 range: 5,
-                newset: dyno.createSet(['b'], 'S').contents
+                newset: Dyno.createSet(['b'], 'S').contents
             }, 'item was really updated');
             t.end();
         });

--- a/test/test.serialization.js
+++ b/test/test.serialization.js
@@ -1,0 +1,159 @@
+var Dyno = require('..');
+var test = require('tape');
+
+var original = {
+    str: 'a string',
+    num: 2,
+    bin: new Buffer('a binary'),
+    bool: true,
+    nothin: null,
+    strSet: Dyno.createSet(['a', 'b', 'c'], 'S'),
+    numSet: Dyno.createSet([1, 2, 3], 'N'),
+    binSet: Dyno.createSet([new Buffer('a'), new Buffer('b'), new Buffer('c')], 'B'),
+    list: ['1', 2, new Buffer('three'), false],
+    B: 'a trap',
+    map: {
+        nested: {
+            str: 'a string',
+            num: 2,
+            bin: new Buffer('a binary'),
+            bool: true,
+            nothin: null,
+            strSet: Dyno.createSet(['a', 'b', 'c'], 'S'),
+            numSet: Dyno.createSet([1, 2, 3], 'N'),
+            binSet: Dyno.createSet([new Buffer('a'), new Buffer('b'), new Buffer('c')], 'B'),
+            list: ['1', 2, new Buffer('three'), false]
+        }
+    },
+    trickyMap: {
+        SS: [1, 2, 3],
+        BS: ['1', 2, new Buffer('three'), false],
+        B: Dyno.createSet(['a', 'b', 'c'], 'S')
+    }
+};
+
+var expected = {
+    str: { S: 'a string' },
+    num: { N: '2' },
+    bin: { B: 'YSBiaW5hcnk=' },
+    bool: { BOOL: true },
+    nothin: { NULL: true },
+    strSet: {
+        SS: ['a', 'b', 'c']
+    },
+    numSet: {
+        NS: ['1', '2', '3']
+    },
+    binSet: {
+        BS: ['YQ==', 'Yg==', 'Yw==']
+    },
+    list: {
+        L: [
+            { S: '1' },
+            { N: '2' },
+            { B: 'dGhyZWU=' },
+            { BOOL: false }
+        ]
+    },
+    B: { S: 'a trap' },
+    map: {
+        M: {
+            nested: {
+                M: {
+                    str: { S: 'a string' },
+                    num: { N: '2' },
+                    bin: { B: 'YSBiaW5hcnk=' },
+                    bool: { BOOL: true },
+                    nothin: { NULL: true },
+                    strSet: {
+                        SS: ['a', 'b', 'c']
+                    },
+                    numSet: {
+                        NS: ['1', '2', '3']
+                    },
+                    binSet: {
+                        BS: ['YQ==', 'Yg==', 'Yw==']
+                    },
+                    list: {
+                        L: [
+                            { S: '1' },
+                            { N: '2' },
+                            { B: 'dGhyZWU=' },
+                            { BOOL: false }
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    trickyMap: {
+        M: {
+            SS: {
+                L: [
+                    { N: '1' },
+                    { N: '2' },
+                    { N: '3' }
+                ]
+            },
+            BS: {
+                L: [
+                    { S: '1' },
+                    { N: '2' },
+                    { B: 'dGhyZWU=' },
+                    { BOOL: false }
+                ]
+            },
+            B: {
+                SS: ['a', 'b', 'c']
+            }
+        }
+    }
+};
+
+test('[serialization]', function(assert) {
+    var str = Dyno.serialize(original);
+    assert.ok(typeof str === 'string', 'serializes to a string');
+    assert.equal(str, JSON.stringify(expected), 'expected serialized string');
+
+    var roundtrip = Dyno.deserialize(str);
+    assert.ok(typeof roundtrip === 'object', 'deserializes from a string');
+
+    assert.equal(roundtrip.str, original.str, 'round-trips str attribute');
+    assert.equal(roundtrip.num, original.num, 'round-trips num attribute');
+    assert.deepEqual(roundtrip.bin, original.bin, 'round-trips bin attribute');
+    assert.equal(roundtrip.bool, original.bool, 'round-trips bool attribute');
+    assert.equal(roundtrip.nothin, original.nothin, 'round-trips null attribute');
+    assert.equal(roundtrip.B, original.B, 'round-trips str attribute called B');
+
+    assert.equal(roundtrip.strSet.datatype, original.strSet.datatype, 'round-trips SS datatype');
+    assert.deepEqual(roundtrip.strSet.contents, original.strSet.contents, 'round-trips SS contents');
+    assert.equal(roundtrip.numSet.datatype, original.numSet.datatype, 'round-trips NS datatype');
+    assert.deepEqual(roundtrip.numSet.contents, original.numSet.contents, 'round-trips NS contents');
+    assert.equal(roundtrip.binSet.datatype, original.binSet.datatype, 'round-trips BS datatype');
+    assert.deepEqual(roundtrip.binSet.contents, original.binSet.contents, 'round-trips BS contents');
+
+    assert.deepEqual(roundtrip.list, original.list, 'round-trips list attribute');
+
+    assert.deepEqual(roundtrip.map.nested.str, original.map.nested.str, 'round-trips map str attribute');
+    assert.deepEqual(roundtrip.map.nested.num, original.map.nested.num, 'round-trips map num attribute');
+    assert.deepEqual(roundtrip.map.nested.bin, original.map.nested.bin, 'round-trips map bin attribute');
+    assert.deepEqual(roundtrip.map.nested.bool, original.map.nested.bool, 'round-trips map bool attribute');
+    assert.deepEqual(roundtrip.map.nested.nothin, original.map.nested.nothin, 'round-trips map null attribute');
+
+    assert.equal(roundtrip.map.nested.strSet.datatype, original.map.nested.strSet.datatype, 'round-trips map SS datatype');
+    assert.deepEqual(roundtrip.map.nested.strSet.contents, original.map.nested.strSet.contents, 'round-trips map SS contents');
+    assert.equal(roundtrip.map.nested.numSet.datatype, original.map.nested.numSet.datatype, 'round-trips map NS datatype');
+    assert.deepEqual(roundtrip.map.nested.numSet.contents, original.map.nested.numSet.contents, 'round-trips map NS contents');
+    assert.equal(roundtrip.map.nested.binSet.datatype, original.map.nested.binSet.datatype, 'round-trips map BS datatype');
+    assert.deepEqual(roundtrip.map.nested.binSet.contents, original.map.nested.binSet.contents, 'round-trips map BS contents');
+
+    assert.deepEqual(roundtrip.map.nested.list, original.map.nested.list, 'round-trips map list attribute');
+
+    assert.deepEqual(roundtrip.trickyMap.SS, original.trickyMap.SS, 'round-trips a list with SS key');
+    assert.deepEqual(roundtrip.trickyMap.BS, original.trickyMap.BS, 'round-trips a list with a BS key');
+
+    assert.equal(roundtrip.trickyMap.B.datatype, original.trickyMap.B.datatype, 'round-trips a SS datatype with BS key');
+    assert.deepEqual(roundtrip.trickyMap.B.contents, original.trickyMap.B.contents, 'round-trips a SS contents with BS key');
+
+    assert.end();
+});


### PR DESCRIPTION
Adds dependency on part of [dynamodb-doc](https://github.com/awslabs/dynamodb-document-js-sdk), which does two-way, recursive transforms between native JavaScript objects and the DynamoDB wire format.

- Add support for [document types (List and Map)][1], [Boolean][2], and [Null][3]
- Native JavaScript arrays will now transform into lists instead of sets
- Add `dyno.createSet()`, which constructs sets (of number, string, or binary
  type) that transform to the DynamoDB wire format correctly.
- Drop support for using a wire-formatted object as input.

[1]:http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModel.DataTypes.Document
[2]:http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModel.DataTypes.Boolean
[3]:http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModel.DataTypes.Null

Fixes https://github.com/mapbox/dyno/issues/41

/cc @rclark @jakepruitt @emilymcafee 