### PR TITLE
de/serialize functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ dyno local table my-table
 
 ##### Scan a table:
 
-Outputs line delimited JSON for every item in the table.
+Outputs line delimited JSON in wire-format for every item in the table.
 
 ```
 dyno local scan my-table
 
-{"id":"0.9410678697749972","collection":"somethign:0","attr":"moredata 64"}
-{"id":"0.9417226337827742","collection":"somethign:0","attr":"moredata 24"}
-{"id":"0.9447696127463132","collection":"somethign:0","attr":"moredata 48"}
-{"id":"0.9472108569461852","collection":"somethign:0","attr":"moredata 84"}
+{"id":{"N":"0.9410678697749972"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 64"}}
+{"id":{"N":"0.9417226337827742"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 24"}}
+{"id":{"N":"0.9447696127463132"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 48"}}
+{"id":{"N":"0.9472108569461852"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 84"}}
 ....
 
 ```
@@ -94,10 +94,10 @@ Outputs the table schema then does a scan (like above)
 dyno local export my-table
 
 {"AttributeDefinitions":[{"AttributeName":"collection","AttributeType":"S"},...]}
-{"id":"0.9410678697749972","collection":"somethign:0","attr":"moredata 64"}
-{"id":"0.9417226337827742","collection":"somethign:0","attr":"moredata 24"}
-{"id":"0.9447696127463132","collection":"somethign:0","attr":"moredata 48"}
-{"id":"0.9472108569461852","collection":"somethign:0","attr":"moredata 84"}
+{"id":{"N":"0.9410678697749972"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 64"}}
+{"id":{"N":"0.9417226337827742"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 24"}}
+{"id":{"N":"0.9447696127463132"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 48"}}
+{"id":{"N":"0.9472108569461852"},"collection":{"S":"somethign:0"},"attr":{"S":"moredata 84"}}
 ....
 
 ```

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -69,11 +69,7 @@ function Stringifier() {
     stringifier._readableState.objectMode = false;
 
     stringifier._transform = function(record, enc, callback) {
-        var str = JSON.stringify(record, function(key, value) {
-            var val = this[key];
-            if (Buffer.isBuffer(val)) return 'base64:' + val.toString('base64');
-            return value;
-        });
+        var str = Dyno.serialize(record);
 
         this.push(str + '\n');
         setImmediate(callback);
@@ -91,14 +87,7 @@ function Parser() {
     parser._transform = function(record, enc, callback) {
         if (!record) return;
 
-        record = JSON.parse(record);
-
-        var val;
-        for (var key in record) {
-            val = record[key];
-            if (typeof val === 'string' && val.indexOf('base64:') === 0)
-                record[key] = new Buffer(val.split('base64:').pop(), 'base64');
-        }
+        record = Dyno.deserialize(record);
 
         this.push(record);
         setImmediate(callback);

--- a/index.js
+++ b/index.js
@@ -28,9 +28,55 @@ Dyno.multi = function(readConfig, writeConfig) {
 };
 
 var types = require('./lib/types');
-Dyno.createSet = types.createSet;
-Dyno.toDynamoTypes = types.toDynamoTypes;
-Dyno.typesFromDynamo = types.typesFromDynamo;
+Dyno.createSet = types.createSet.bind(types);
+
+Dyno.serialize = function(item) {
+    function replacer(key, value) {
+        if (Buffer.isBuffer(this[key])) return this[key].toString('base64');
+
+        if (this[key].BS &&
+            Array.isArray(this[key].BS) &&
+            _(this[key].BS).every(function(buf) {
+                return Buffer.isBuffer(buf);
+            }))
+        {
+            return {
+                BS: this[key].BS.map(function(buf) {
+                    return buf.toString('base64');
+                })
+            };
+        }
+
+        return value;
+    }
+
+    return JSON.stringify(types.toDynamoTypes(item), replacer);
+};
+
+Dyno.deserialize = function(str) {
+    function reviver(key, value) {
+        if (typeof value === 'object' && value.B && typeof value.B === 'string') {
+            return { B: new Buffer(value.B, 'base64') };
+        }
+
+        if (typeof value === 'object' &&
+            value.BS &&
+            Array.isArray(value.BS))
+        {
+            return {
+                BS: value.BS.map(function(s) {
+                    return new Buffer(s, 'base64');
+                })
+            };
+        }
+
+        return value;
+    }
+
+    str = JSON.parse(str, reviver);
+    str = types.typesFromDynamo(str);
+    return str[0];
+};
 
 function badconfig(message) {
     var err = new Error(message);

--- a/test/index.js
+++ b/test/index.js
@@ -7,3 +7,4 @@ require('./test.table');
 require('./test.kinesis');
 require('./test.multi');
 require('./test.config');
+require('./test.serialization');

--- a/test/test.cli.js
+++ b/test/test.cli.js
@@ -7,6 +7,7 @@ var fixtures = require('./fixtures');
 var setup = require('./setup')();
 var test = setup.test;
 var dyno = setup.dyno;
+var Dyno = require('..');
 
 // use --verbose to print cli output to terminal during the test run
 var verbose = process.argv.indexOf('--verbose') > -1;
@@ -150,7 +151,7 @@ test('cli: export table', function(assert) {
             assert.deepEqual(table, cleanedTable, 'printed cleaned table definition to stdout');
 
             var expectedRecords = records.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             var intersection = _.intersection(expectedRecords, results);
@@ -177,7 +178,7 @@ test('cli: scan table', function(assert) {
             var results = stdout.trim().split('\n');
 
             var expectedRecords = records.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             var intersection = _.intersection(expectedRecords, results);
@@ -192,7 +193,7 @@ test('cli: setup', setup.setup());
 test('cli: import table', function(assert) {
     var records = fixtures.randomItems(10);
     var serialized = _.union([cleanedTable], records).map(function(line) {
-        return JSON.stringify(line);
+        return Dyno.serialize(line);
     }).join('\n');
 
     var proc = runCli(['import', 'local/' + setup.tableName], function(err, stdout, stderr) {
@@ -204,11 +205,11 @@ test('cli: import table', function(assert) {
             }
 
             var expectedRecords = records.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             items = items.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             var intersection = _.intersection(expectedRecords, items);
@@ -229,7 +230,7 @@ test('cli: setup table', setup.setupTable);
 test('cli: import data', function(assert) {
     var records = fixtures.randomItems(10);
     var serialized = records.map(function(line) {
-        return JSON.stringify(line);
+        return Dyno.serialize(line);
     }).join('\n');
 
     var proc = runCli(['put', 'local/' + setup.tableName], function(err, stdout, stderr) {
@@ -241,11 +242,11 @@ test('cli: import data', function(assert) {
             }
 
             var expectedRecords = records.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             items = items.map(function(record) {
-                return JSON.stringify(record);
+                return Dyno.serialize(record);
             });
 
             var intersection = _.intersection(expectedRecords, items);
@@ -279,7 +280,7 @@ test('cli: export complicated record', function(assert) {
 
         runCli(['scan', 'local/' + setup.tableName], function(err, stdout, stderr) {
             assert.ifError(err, 'cli success');
-            assert.equal(stdout.trim(), '{"id":"id:1","range":1,"buffer":"base64:aGVsbG8gd29ybGQh","array":[0,1,2],"newline":"0\\n1"}', 'printed record to stdout');
+            assert.equal(stdout.trim(), '{"id":{"S":"id:1"},"range":{"N":"1"},"buffer":{"B":"aGVsbG8gd29ybGQh"},"array":{"L":[{"N":"0"},{"N":"1"},{"N":"2"}]},"newline":{"S":"0\\n1"}}', 'printed record to stdout');
             assert.end();
         });
     });
@@ -312,7 +313,7 @@ test('cli: import complicated record', function(assert) {
         });
     });
 
-    proc.stdin.write('{"id":"id:1","range":1,"buffer":"base64:aGVsbG8gd29ybGQh","array":[0,1,2],"newline":"0\\n1"}');
+    proc.stdin.write('{"id":{"S":"id:1"},"range":{"N":"1"},"buffer":{"B":"aGVsbG8gd29ybGQh"},"array":{"L":[{"N":"0"},{"N":"1"},{"N":"2"}]},"newline":{"S":"0\\n1"}}');
     proc.stdin.end();
 });
 test('cli: deleteTable', setup.deleteTable);

--- a/test/test.serialization.js
+++ b/test/test.serialization.js
@@ -1,0 +1,79 @@
+var Dyno = require('..');
+var test = require('tape');
+
+var original = {
+    str: 'a string',
+    num: 2,
+    bin: new Buffer('a binary'),
+    bool: true,
+    nothin: null,
+    strSet: Dyno.createSet(['a', 'b', 'c'], 'S'),
+    numSet: Dyno.createSet([1, 2, 3], 'N'),
+    binSet: Dyno.createSet([new Buffer('a'), new Buffer('b'), new Buffer('c')], 'B'),
+    list: ['1', 2, new Buffer('three'), false],
+    B: 'a trap',
+    map: {
+        nested: {
+            str: 'a string',
+            num: 2,
+            bin: new Buffer('a binary'),
+            bool: true,
+            nothin: null,
+            strSet: Dyno.createSet(['a', 'b', 'c'], 'S'),
+            numSet: Dyno.createSet([1, 2, 3], 'N'),
+            binSet: Dyno.createSet([new Buffer('a'), new Buffer('b'), new Buffer('c')], 'B'),
+            list: ['1', 2, new Buffer('three'), false]
+        }
+    },
+    trickyMap: {
+        SS: [1, 2, 3],
+        BS: ['1', 2, new Buffer('three'), false],
+        B: Dyno.createSet(['a', 'b', 'c'], 'S')
+    }
+};
+
+test('[serialization]', function(assert) {
+    var str = Dyno.serialize(original);
+    assert.ok(typeof str === 'string', 'serializes to a string');
+    var roundtrip = Dyno.deserialize(str);
+    assert.ok(typeof roundtrip === 'object', 'deserializes from a string');
+
+    assert.equal(roundtrip.str, original.str, 'round-trips str attribute');
+    assert.equal(roundtrip.num, original.num, 'round-trips num attribute');
+    assert.deepEqual(roundtrip.bin, original.bin, 'round-trips bin attribute');
+    assert.equal(roundtrip.bool, original.bool, 'round-trips bool attribute');
+    assert.equal(roundtrip.nothin, original.nothin, 'round-trips null attribute');
+    assert.equal(roundtrip.B, original.B, 'round-trips str attribute called B');
+
+    assert.equal(roundtrip.strSet.datatype, original.strSet.datatype, 'round-trips SS datatype');
+    assert.deepEqual(roundtrip.strSet.contents, original.strSet.contents, 'round-trips SS contents');
+    assert.equal(roundtrip.numSet.datatype, original.numSet.datatype, 'round-trips NS datatype');
+    assert.deepEqual(roundtrip.numSet.contents, original.numSet.contents, 'round-trips NS contents');
+    assert.equal(roundtrip.binSet.datatype, original.binSet.datatype, 'round-trips BS datatype');
+    assert.deepEqual(roundtrip.binSet.contents, original.binSet.contents, 'round-trips BS contents');
+
+    assert.deepEqual(roundtrip.list, original.list, 'round-trips list attribute');
+
+    assert.deepEqual(roundtrip.map.nested.str, original.map.nested.str, 'round-trips map str attribute');
+    assert.deepEqual(roundtrip.map.nested.num, original.map.nested.num, 'round-trips map num attribute');
+    assert.deepEqual(roundtrip.map.nested.bin, original.map.nested.bin, 'round-trips map bin attribute');
+    assert.deepEqual(roundtrip.map.nested.bool, original.map.nested.bool, 'round-trips map bool attribute');
+    assert.deepEqual(roundtrip.map.nested.nothin, original.map.nested.nothin, 'round-trips map null attribute');
+
+    assert.equal(roundtrip.map.nested.strSet.datatype, original.map.nested.strSet.datatype, 'round-trips map SS datatype');
+    assert.deepEqual(roundtrip.map.nested.strSet.contents, original.map.nested.strSet.contents, 'round-trips map SS contents');
+    assert.equal(roundtrip.map.nested.numSet.datatype, original.map.nested.numSet.datatype, 'round-trips map NS datatype');
+    assert.deepEqual(roundtrip.map.nested.numSet.contents, original.map.nested.numSet.contents, 'round-trips map NS contents');
+    assert.equal(roundtrip.map.nested.binSet.datatype, original.map.nested.binSet.datatype, 'round-trips map BS datatype');
+    assert.deepEqual(roundtrip.map.nested.binSet.contents, original.map.nested.binSet.contents, 'round-trips map BS contents');
+
+    assert.deepEqual(roundtrip.map.nested.list, original.map.nested.list, 'round-trips map list attribute');
+
+    assert.deepEqual(roundtrip.trickyMap.SS, original.trickyMap.SS, 'round-trips a list with SS key');
+    assert.deepEqual(roundtrip.trickyMap.BS, original.trickyMap.BS, 'round-trips a list with a BS key');
+
+    assert.equal(roundtrip.trickyMap.B.datatype, original.trickyMap.B.datatype, 'round-trips a SS datatype with BS key');
+    assert.deepEqual(roundtrip.trickyMap.B.contents, original.trickyMap.B.contents, 'round-trips a SS contents with BS key');
+
+    assert.end();
+});

--- a/test/test.serialization.js
+++ b/test/test.serialization.js
@@ -32,9 +32,89 @@ var original = {
     }
 };
 
+var expected = {
+    str: { S: 'a string' },
+    num: { N: '2' },
+    bin: { B: 'YSBiaW5hcnk=' },
+    bool: { BOOL: true },
+    nothin: { NULL: true },
+    strSet: {
+        SS: ['a', 'b', 'c']
+    },
+    numSet: {
+        NS: ['1', '2', '3']
+    },
+    binSet: {
+        BS: ['YQ==', 'Yg==', 'Yw==']
+    },
+    list: {
+        L: [
+            { S: '1' },
+            { N: '2' },
+            { B: 'dGhyZWU=' },
+            { BOOL: false }
+        ]
+    },
+    B: { S: 'a trap' },
+    map: {
+        M: {
+            nested: {
+                M: {
+                    str: { S: 'a string' },
+                    num: { N: '2' },
+                    bin: { B: 'YSBiaW5hcnk=' },
+                    bool: { BOOL: true },
+                    nothin: { NULL: true },
+                    strSet: {
+                        SS: ['a', 'b', 'c']
+                    },
+                    numSet: {
+                        NS: ['1', '2', '3']
+                    },
+                    binSet: {
+                        BS: ['YQ==', 'Yg==', 'Yw==']
+                    },
+                    list: {
+                        L: [
+                            { S: '1' },
+                            { N: '2' },
+                            { B: 'dGhyZWU=' },
+                            { BOOL: false }
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    trickyMap: {
+        M: {
+            SS: {
+                L: [
+                    { N: '1' },
+                    { N: '2' },
+                    { N: '3' }
+                ]
+            },
+            BS: {
+                L: [
+                    { S: '1' },
+                    { N: '2' },
+                    { B: 'dGhyZWU=' },
+                    { BOOL: false }
+                ]
+            },
+            B: {
+                SS: ['a', 'b', 'c']
+            }
+        }
+    }
+};
+
 test('[serialization]', function(assert) {
     var str = Dyno.serialize(original);
     assert.ok(typeof str === 'string', 'serializes to a string');
+    assert.equal(str, JSON.stringify(expected), 'expected serialized string');
+
     var roundtrip = Dyno.deserialize(str);
     assert.ok(typeof roundtrip === 'object', 'deserializes from a string');
 


### PR DESCRIPTION
- Adds serialize function (takes a dyno item, converts it to wire format, JSON.stringifies it)
- Adds deserialize function (takes a string from above, JSON.parses it, converts it to dyno format)

cc @willwhite feel free to try and add more "tricky" cases to the test. The difficult part of all this is dealing with buffer objects, and turning them into round-tripable strings