### PR TITLE
[wip] Estimate item size

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -115,5 +115,117 @@ module.exports = function(config) {
         });
     };
 
+    /**
+     * Estimate the total size of an item, including any local secondary index items
+     * @param {object} doc - the item
+     * @param {object} tabledef - JSON object defining the table's schema
+     * @return {number} the number of bytes required to store the item
+     */
+    items.estimateSize = function(doc, tabledef) {
+        doc = JSON.parse(require('..').serialize(doc));
+        var range = tabledef.KeySchema.filter(function(key) { return key.KeyType === 'RANGE'; })[0];
+
+        // http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html
+        // For each local secondary index on a table, there is a 400 KB limit on the total size of the following:
+        // - The size of an item's data in the table.
+        // - The size of the local secondary index entry corresponding to that item, including its key values and projected attributes.
+        var lsis = (tabledef.LocalSecondaryIndexes || []).map(function(lsi) {
+            var result = {
+                hash: lsi.KeySchema.filter(function(key) { return key.KeyType === 'HASH'; })[0].AttributeName,
+                index: lsi.KeySchema.filter(function(key) { return key.KeyType === 'RANGE'; })[0].AttributeName
+            };
+
+            if (range)
+                result.range = range.AttributeName;
+            if (lsi.Projection.ProjectionType === 'ALL')
+                result.projection = 'all';
+            if (lsi.Projection.ProjectionType === 'INCLUDE')
+                result.projection = lsi.Projection.NonKeyAttributes;
+
+            return result;
+        });
+
+        var docSize = itemSize(0, doc);
+        lsis.forEach(function(lsi) {
+            var size = lsiSize(doc, lsi);
+            docSize += size;
+        });
+
+        return docSize;
+    };
+
     return items;
 };
+
+function itemSize(total, doc) {
+    return Object.keys(doc).reduce(function(total, key) {
+        if (typeof doc[key] === 'object') {
+            var type = Object.keys(doc[key])[0];
+            var val = doc[key][type];
+            total += attrSize(key, type, val);
+        } else {
+            total += attrSize([], key, doc[key]);
+        }
+
+        return total;
+    }, total);
+}
+
+function lsiSize(doc, lsi) {
+    if (!doc[lsi.index]) return 0;
+
+    // http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LSI.html#LSI.StorageConsiderations
+    // 100 bytes of overhead per index item
+    var size = 100;
+
+    // The size in bytes of the table primary key (hash and range key attributes)
+    var keys = {};
+    if (lsi.range) keys[lsi.range] = doc[lsi.range];
+    keys[lsi.hash] = doc[lsi.hash];
+
+    // The size in bytes of the index key attribute
+    keys[lsi.index] = doc[lsi.index];
+
+    size = itemSize(size, keys);
+
+    // The size in bytes of the projected attributes (if any)
+    if (!lsi.projected) return size;
+
+    if (lsi.projected === 'all') lsi.projected = Object.keys(doc);
+    var projection = lsi.projected.reduce(function(projection, key) {
+        if (key !== lsi.hash && key !== lsi.range && key !== lsi.index)
+            projection[key] = doc[key];
+        return projection;
+    }, {});
+
+    size += itemSize(0, projection);
+
+    return size;
+}
+
+function attrSize(name, type, val) {
+    // http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#CapacityUnitCalculations
+    // The size of an item is the sum of the lengths of its attribute names and values.
+    var sum = name.length;
+    if (type === 'N' || type === 'S') sum += val.length;
+    if (type === 'NS' || type === 'SS') sum += val.reduce(function(sum, num) {
+        sum += num.length;
+        return sum;
+    }, 0);
+    if (type === 'B') sum += (new Buffer(val, 'base64')).length;
+    if (type === 'BS') sum += val.reduce(function(sum, buf) {
+        sum += (new Buffer(buf, 'base64')).length;
+        return sum;
+    }, 0);
+
+    // The size of a Null or Boolean attribute value is (length of the attribute name + one byte).
+    if (type === 'BOOL' || type === 'NULL') sum += 1;
+
+    // An attribute of type List or Map requires 3 bytes of overhead, regardless of its contents.
+    if (type === 'L' || type === 'M') sum += 3;
+    // If the attribute is non-empty, the size is (length of the attribute name + sum (length of attribute values) + 3 bytes).
+    if (type === 'L') sum += val.reduce(itemSize, 0);
+    if (type === 'M') sum += itemSize(0, val);
+
+    return sum;
+}

--- a/lib/item.js
+++ b/lib/item.js
@@ -189,10 +189,10 @@ function lsiSize(doc, lsi) {
     size = itemSize(size, keys);
 
     // The size in bytes of the projected attributes (if any)
-    if (!lsi.projected) return size;
+    if (!lsi.projection) return size;
 
-    if (lsi.projected === 'all') lsi.projected = Object.keys(doc);
-    var projection = lsi.projected.reduce(function(projection, key) {
+    if (lsi.projection === 'all') lsi.projection = Object.keys(doc);
+    var projection = lsi.projection.reduce(function(projection, key) {
         if (key !== lsi.hash && key !== lsi.range && key !== lsi.index)
             projection[key] = doc[key];
         return projection;

--- a/test/index.js
+++ b/test/index.js
@@ -8,3 +8,4 @@ require('./test.batch');
 require('./test.config');
 require('./test.serialization');
 require('./test.multi');
+require('./test.itemsize.js');

--- a/test/test.itemsize.js
+++ b/test/test.itemsize.js
@@ -1,0 +1,203 @@
+var test = require('tape');
+var fixtures = require('./fixtures');
+var _ = require('underscore');
+var dyno = require('..')({ table: 'fake' });
+
+test('[item size] simple, no LSI', function(assert) {
+    var table = _.clone(fixtures.test);
+
+    // attribute names + hash/range values should add 16 to the byte count
+    var item = fixtures.randomItems(1, 100)[0];
+    var found = dyno.estimateSize(item, table);
+    assert.equal(found, 116, 'correct size estimation');
+
+    item = fixtures.randomItems(1, 1000)[0];
+    found = dyno.estimateSize(item, table);
+    assert.equal(found, 1016, 'correct size estimation');
+
+    assert.end();
+});
+
+test('[item size] simple, LSI KEYS_ONLY', function(assert) {
+    var table = _.clone(fixtures.test);
+
+    table.AttributeDefinitions.push({
+        AttributeName: 'index',
+        AttributeType: 'S'
+    });
+
+    table.LocalSecondaryIndexes = [
+        {
+            IndexName: 'index',
+            KeySchema: [
+                {
+                    AttributeName: 'id',
+                    KeyType: 'HASH'
+                },
+                {
+                    AttributeName: 'index',
+                    KeyType: 'RANGE'
+                }
+            ],
+            Projection: {
+                ProjectionType: 'KEYS_ONLY'
+            }
+        }
+    ];
+
+    var item = fixtures.randomItems(1, 100)[0];
+    item.index = 'abc';
+
+    // Should end up with:
+    // - 100 + 16 + 8 for the record
+    // - 100 lsi overhead
+    // - hash/range/index = 6/6/8
+    // ==> 244
+    found = dyno.estimateSize(item, table);
+    assert.equal(found, 244, 'correct size estimation');
+    assert.end();
+});
+
+test('[item size] simple, LSI ALL', function(assert) {
+    var table = _.clone(fixtures.test);
+
+    table.AttributeDefinitions.push({
+        AttributeName: 'index',
+        AttributeType: 'S'
+    });
+
+    table.LocalSecondaryIndexes = [
+        {
+            IndexName: 'index',
+            KeySchema: [
+                {
+                    AttributeName: 'id',
+                    KeyType: 'HASH'
+                },
+                {
+                    AttributeName: 'index',
+                    KeyType: 'RANGE'
+                }
+            ],
+            Projection: {
+                ProjectionType: 'ALL'
+            }
+        }
+    ];
+
+    var item = fixtures.randomItems(1, 100)[0];
+    item.index = 'abc';
+
+    // Should end up with:
+    // - 100 + 16 + 8 for the record
+    // - 100 lsi overhead
+    // - 100 + 16 + 8 again for the projected record
+    // ==> 348
+    found = dyno.estimateSize(item, table);
+    assert.equal(found, 348, 'correct size estimation');
+    assert.end();
+});
+
+test('[item size] simple, LSI INCLUDE', function(assert) {
+    var table = _.clone(fixtures.test);
+
+    table.AttributeDefinitions.push({
+        AttributeName: 'index',
+        AttributeType: 'S'
+    });
+
+    table.LocalSecondaryIndexes = [
+        {
+            IndexName: 'index',
+            KeySchema: [
+                {
+                    AttributeName: 'id',
+                    KeyType: 'HASH'
+                },
+                {
+                    AttributeName: 'index',
+                    KeyType: 'RANGE'
+                }
+            ],
+            Projection: {
+                ProjectionType: 'INCLUDE',
+                NonKeyAttributes: [
+                    'extra'
+                ]
+            }
+        }
+    ];
+
+    var item = fixtures.randomItems(1, 100)[0];
+    item.index = 'abc';
+    item.extra = '123';
+
+    // Should end up with:
+    // - 100 + 16 + 8 + 8 for the record
+    // - 100 lsi overhead
+    // - hash/range/index = 6/6/8
+    // - 8 for the projected attribute
+    // ==> 260
+    found = dyno.estimateSize(item, table);
+    assert.equal(found, 260, 'correct size estimation');
+    assert.end();
+});
+
+test('[item size] simple, LSI avoided', function(assert) {
+    var table = _.clone(fixtures.test);
+
+    table.AttributeDefinitions.push({
+        AttributeName: 'index',
+        AttributeType: 'S'
+    });
+
+    table.LocalSecondaryIndexes = [
+        {
+            IndexName: 'index',
+            KeySchema: [
+                {
+                    AttributeName: 'id',
+                    KeyType: 'HASH'
+                },
+                {
+                    AttributeName: 'index',
+                    KeyType: 'RANGE'
+                }
+            ],
+            Projection: {
+                ProjectionType: 'KEYS_ONLY'
+            }
+        }
+    ];
+
+    var item = fixtures.randomItems(1, 100)[0];
+
+    // Should end up with:
+    // - 100 + 16 for the record
+    // ==> 116
+    found = dyno.estimateSize(item, table);
+    assert.equal(found, 116, 'correct size estimation');
+    assert.end();
+});
+
+test('[item size] complex item', function(assert) {
+    var table = _.clone(fixtures.test);
+    var Dyno = require('..');
+
+    var item = fixtures.randomItems(1, 100)[0];    // 116
+    item.e = true;                                   // 2
+    item.f = null;                                   // 2
+    item.a = 'a';                                    // 2
+    item.b = 1;                                      // 2
+    item.g = new Buffer('a');                        // 2
+    item.c = Dyno.createSet(['a', 'b'], 'S');        // 3
+    item.d = Dyno.createSet([1, 2], 'N');            // 3
+    item.h = Dyno.createSet([new Buffer('a')], 'B'); // 2
+    item.i = ['a', 2, new Buffer('a')];              // 7
+    item.j = { a: 'a' };                             // 6
+                                                   // ---
+                                                   // 147
+    found = dyno.estimateSize(item, table);
+    assert.equal(found, 147, 'correct size estimation');
+    assert.end();
+});


### PR DESCRIPTION
Adds a function that calculates the number of bytes required to store an item. This is an "estimate" because the documentation is scattered and not terribly quantitative.

Still needs some tests.