### PR TITLE
Fix Parser process in CLI

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -82,7 +82,7 @@ function Parser() {
     parser._readableState.objectMode = true;
 
     parser._transform = function(record, enc, callback) {
-        if (!record) return;
+        if (!record || record.length == 0) { setImmediate(callback); return; }
 
         record = Dyno.deserialize(record);
 


### PR DESCRIPTION
Fix an "Unexpected end of input" error and make sure the callback is always called otherwise some data remains unprocessed.