### PR TITLE
Configurable batch concurrency

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -31,7 +31,7 @@ module.exports = function(config) {
             chunks[c] = keys.slice(100 * c, 100 * (c + 1));
         }
 
-        var q = queue(10);
+        var q = queue(opts.concurrency || 10);
         var metas = [];
         chunks.forEach(function(keys) {
             requests.Keys = keys;
@@ -57,7 +57,7 @@ module.exports = function(config) {
 
         var table = opts.table || config.table;
         var maxSize = 1024 * 1024;
-        var q = queue(10);
+        var q = queue(opts.concurrency || 10);
 
         var params = {};
         if (opts.capacity) params.ReturnConsumedCapacity = opts.capacity;
@@ -107,7 +107,7 @@ module.exports = function(config) {
             });
             p.RequestItems[table] = putRequests;
             q.defer(function(next) {
-                dynamoRequest('batchWriteItem', p, function(err, res, meta) {
+                dynamoRequest('batchWriteItem', p, opts, function(err, res, meta) {
                     if (err) errors.push(err);
                     next(null, meta);
                 });
@@ -141,7 +141,7 @@ module.exports = function(config) {
             opts = {};
         }
         var table = opts.table || config.table;
-        var q = queue(10);
+        var q = queue(opts.concurrency || 10);
 
         var params = {};
         if (opts.capacity) params.ReturnConsumedCapacity = opts.capacity;
@@ -177,7 +177,7 @@ module.exports = function(config) {
             });
             d.RequestItems[table] = deleteRequests;
             q.defer(function(next) {
-                dynamoRequest('batchWriteItem', d, function(err, res, meta) {
+                dynamoRequest('batchWriteItem', d, opts, function(err, res, meta) {
                     if (err) errors.push(err);
                     next(null, meta);
                 });


### PR DESCRIPTION
Batch requests split your input out into as many individual HTTP requests as needed. This allows you to configure the concurrency with which those requests are made. It defaults to 10 concurrent requests and is overridden via `options.concurrency` when you make the batch request.

cc @mick for 2nd :eyes: 