### PR TITLE
queryBatchGet function

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -1,10 +1,12 @@
 var types = require('./types');
 var _ = require('underscore');
+var stream = require('stream');
 
 module.exports = function(config) {
     var dynamoRequest = require('./dynamoRequest')(config);
+    var batch = require('./batch')(config);
 
-    return {
+    var items = {
         /**
          * Query items from item from a table
          * @param {String} conditions - criteria for the query
@@ -55,6 +57,62 @@ module.exports = function(config) {
             }
 
             return dynamoRequest('query', params, opts, cb);
+        },
+
+        queryBatchGet: function(index, hashKey, conditions, opts, cb) {
+            if (!cb && _.isFunction(opts)) {
+                cb = opts;
+                opts = {};
+            }
+            if (!opts) opts = {};
+
+            var readOpts = _({ index: index }).defaults(opts);
+            var gsiQuery = items.query(conditions, readOpts);
+
+            var batchGet = new stream.Transform({ objectMode: true });
+
+            batchGet.queue = [];
+
+            batchGet.fetch = function(keys, callback) {
+                batch.getItems(keys, opts, function(err, items) {
+                    if (err) return callback(err);
+                    batchGet.queue = [];
+                    items.forEach(function(item) {
+                        batchGet.push(item);
+                    });
+                    callback();
+                });
+            };
+
+            batchGet._transform = function(indexItem, enc, callback) {
+                var key = {};
+                key[hashKey] = indexItem[hashKey];
+
+                batchGet.queue.push(key);
+                if (batchGet.queue.length < 100) return callback();
+                batchGet.fetch(batchGet.queue, callback);
+            };
+
+            batchGet._flush = function(callback) {
+                if (!batchGet.queue.length) return callback();
+                batchGet.fetch(batchGet.queue, callback);
+            };
+
+            if (cb) {
+                var results = [];
+
+                batchGet
+                    .once('error', cb)
+                    .on('data', function(item) { results.push(item); })
+                    .on('end', function() {
+                        cb(null, results);
+                    })
+                    .resume();
+            }
+
+            return gsiQuery.pipe(batchGet);
         }
     };
+
+    return items;
 };

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -31,6 +31,36 @@ module.exports.live = {
     }
 };
 
+module.exports.gsi = {
+    AttributeDefinitions: [
+        { AttributeName: 'id', AttributeType: 'S' },
+        { AttributeName: 'group', AttributeType: 'S' }
+    ],
+    KeySchema: [
+        { AttributeName: 'id', KeyType: 'HASH' }
+    ],
+    ProvisionedThroughput: {
+        ReadCapacityUnits: 1,
+        WriteCapacityUnits: 1
+    },
+    GlobalSecondaryIndexes: [
+        {
+            IndexName: 'gsi',
+            KeySchema: [
+                { AttributeName: 'group', KeyType: 'HASH' },
+                { AttributeName: 'id', KeyType: 'RANGE' }
+            ],
+            Projection: {
+                ProjectionType: 'KEYS_ONLY'
+            },
+            ProvisionedThroughput: {
+                ReadCapacityUnits: 1,
+                WriteCapacityUnits: 1
+            }
+        }
+    ]
+};
+
 module.exports.randomItems = function(n, itemsize) {
     var items = [];
     var rng = seedrandom('test');

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ require('./test.item');
 require('./test.table');
 require('./test.kinesis');
 require('./test.batch');
+require('./test.queryBatchGet');
 require('./test.config');
 require('./test.serialization');
 require('./test.multi');

--- a/test/test.queryBatchGet.js
+++ b/test/test.queryBatchGet.js
@@ -1,0 +1,64 @@
+var fixtures = require('./fixtures');
+var tape = require('tape');
+var crypto = require('crypto');
+var queue = require('queue-async');
+var _ = require('underscore');
+var Dyno = require('..');
+var Dynalite = require('dynalite');
+var dynalite = Dynalite({
+    createTableMs: 0,
+    updateTableMs: 0,
+    deleteTableMs: 0
+});
+
+function test(label, callback) {
+    var name = crypto.randomBytes(4).toString('hex');
+    var table = _({ TableName: name }).extend(fixtures.gsi);
+    var dyno = Dyno({
+        table: name,
+        region: 'fake',
+        endpoint: 'http://localhost:4567'
+    });
+
+    tape(label, function(t) {
+        var end = t.end.bind(t);
+        t.end = function() {
+            queue(1)
+                .defer(dyno.deleteTable, table)
+                .defer(dynalite.close)
+                .awaitAll(end);
+        };
+
+        queue(1)
+            .defer(dynalite.listen.bind(dynalite), 4567)
+            .defer(dyno.createTable, table)
+            .awaitAll(function(err) {
+                if (err) throw err;
+                callback.call({ dyno: dyno }, t);
+            });
+    });
+}
+
+test('[queryBatchGet]', function(assert) {
+    var data = fixtures.randomItems(300).map(function(item, i) {
+        item.group = i < 150 ? 'a' : 'b';
+        delete item.data;
+        return item;
+    });
+
+    var dyno = this.dyno;
+
+    dyno.putItems(data, function(err) {
+        if (err) throw err;
+
+        var query = { group: { EQ: 'a' } };
+        dyno.queryBatchGet('gsi', 'id', query, function(err, items) {
+            assert.ifError(err, 'success');
+            var sorted = _(items).sortBy(function(item) {
+                return Number(item.id.split(':')[1]);
+            });
+            assert.deepEqual(sorted, data.slice(0, 150), 'returned appropriate items');
+            assert.end();
+        });
+    });
+});


### PR DESCRIPTION
Refs #101, adding a function specific to a hash-only table with a keys-only GSI. Queries the GSI, then batch gets all the items via hash key.

There's room for this to be more flexible to do bath gets in a hash-range key, but it requires more table schema knowledge. See #102 for some related ideas.

cc @willwhite 