### PR TITLE
Native types for LastEvaluatedKey and ExclusiveStartKey.

### DIFF
--- a/lib/dynamoRequest.js
+++ b/lib/dynamoRequest.js
@@ -75,7 +75,7 @@ module.exports = function(config) {
         if (opts.pages === undefined && callback) opts.pages = 1;
         if (!opts.pages) opts.pages = Infinity;
 
-        if (!streamMode) request(opts.start);
+        if (!streamMode) request(opts.start ? types.toDynamoTypes(opts.start) : null);
 
         function request(start) {
             currentKey = false;
@@ -141,7 +141,7 @@ module.exports = function(config) {
 
                 var meta = {};
                 if (resp.ConsumedCapacity) meta.capacity = resp.ConsumedCapacity;
-                if (resp.LastEvaluatedKey) meta.last = resp.LastEvaluatedKey;
+                if (resp.LastEvaluatedKey) meta.last = types.typesFromDynamo(resp.LastEvaluatedKey)[0];
                 metas.push(meta);
 
                 page++;

--- a/lib/query.js
+++ b/lib/query.js
@@ -40,9 +40,6 @@ module.exports = function(config) {
             if (opts.limit) {
                 params.Limit = opts.limit;
             }
-            if (opts.start) {
-                params.ExclusiveStartKey = opts.start;
-            }
             if (opts.attributes) {
                 params.AttributesToGet = opts.attributes;
                 params.Select = 'SPECIFIC_ATTRIBUTES';

--- a/test/test.item.js
+++ b/test/test.item.js
@@ -261,16 +261,17 @@ test('query - callback, paging get all pages', function(t) {
     }
 });
 
-test('query - callback, paging via prev/next', function(t) {
+test('query - callback, paging via start', function(t) {
 
     dyno.query({id:{EQ:'yo'}}, {limit:1, pages:1}, firstResp);
 
     function firstResp(err, items, metas) {
         t.equal(err, null);
         t.equal(items.length, 1);
-        t.deepEqual(_(items[0]).omit('blob'), {id: 'yo', range:5});
+        t.deepEqual(_(items[0]).omit('blob'), {id: 'yo', range: 5});
         var next = metas.pop().last;
         t.ok(next, 'last evaluated key is not null');
+        t.deepEqual(next, {id: 'yo', range: 5});
         nextQuery(next);
     }
 


### PR DESCRIPTION
- Dyno now uses native format (not wire format) for `metas[*].last` (aka `LastEvaluatedKey`).
- Callers must use native format (not wire format) when passing in `opts.start` (aka `ExclusiveStartKey`).
- Improve robustness of tests slightly because the two changes above didn't cause any tests to fail :grin: 
- Remove dead code that was copying `opts.start` to `params.ExclusiveStartKey`. We are doing this in [dynamoRequest](https://github.com/mapbox/dyno/blob/master/lib/dynamoRequest.js#L83).