### PR TITLE
[wip] Managing batch get/write responses

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -1,12 +1,32 @@
 var big = require('big.js');
 var converter = require('aws-sdk/lib/dynamodb/converter');
 var queue = require('queue-async');
-var _ = require('underscore');
 
 module.exports = function(client) {
   var requests = {};
 
-  function sendAll(requests, concurrency, callback) {
+  /**
+   * Given a set of requests, this function sends them all at specified concurrency.
+   * Emphasis is on making it transparent to the caller the exact outcome of each
+   * request in the set. The callback function will be passed arguments in this
+   * order:
+   * - error: set to null if no errors occurred, otherwise an array of errors with
+   * indexes that correspond to the indexes of the original request set
+   * - responses: always an array of responses equal with indexes corresponding
+   * to the original request set
+   * - unprocessed: set to null if no unprocessed results were detected, otherwise
+   * a new set of requests with its own .sendAll function bound to it. Again,
+   * indexes correspond to those in the original request set.
+   *
+   * @private
+   * @param {RequestSet} requests - an array of AWS.Request objects
+   * @param {string} fnName - the name of the aws-sdk client function that will
+   * be used to construct new requests should an unprocessed items be detected
+   * @param {number} concurrency - the concurrency with which batch requests
+   * will be made
+   * @param {function} callback - a function to handle the response
+   */
+  function sendAll(requests, fnName, concurrency, callback) {
     if (typeof concurrency === 'function') {
       callback = concurrency;
       concurrency = 1;
@@ -16,6 +36,7 @@ module.exports = function(client) {
 
     requests.forEach(function(req) {
       q.defer(function(next) {
+        if (!req) return next();
         req.on('complete', function(response) {
           next(null, response);
         }).send();
@@ -27,30 +48,35 @@ module.exports = function(client) {
 
       var errors = [];
       var data = [];
+      var unprocessed = [];
+
       responses.forEach(function(response) {
         errors.push(response.error);
         data.push(response.data);
+
+        if (!response.data) return unprocessed.push(null);
+
+        var newParams = {
+          RequestItems: response.data.UnprocessedItems || response.data.UnprocessedKeys
+        };
+        unprocessed.push(newParams.RequestItems ? newParams : null);
       });
 
-      var unprocessed = data.reduce(function(unprocessed, data) {
-        if (data.UnprocessedItems) {
-          _(data.UnprocessedItems).each(function(items, table) {
-            unprocessed.RequestItems[table] = unprocessed.RequestItems[table] ?
-              unprocessed.RequestItems[table].concat(items) : items;
-          });
-        }
-        return unprocessed;
-      }, { RequestItems: {} });
-
-      unprocessed = Object.keys(unprocessed.RequestItems).length ?
-        requests.batchWriteItemRequests(unprocessed) : undefined;
-
-      errors = errors.reduce(function(errors, err) {
-        if (err) errors = errors ? errors.concat([err]) : [err];
-        return errors;
+      unprocessed = unprocessed.map(function(params) {
+        if (params) return client[fnName].bind(client)(params);
+        else return null;
       });
 
-      callback(errors, data, unprocessed);
+      var unprocessedCount = unprocessed.filter(function(req) { return !!req; }).length;
+      if (unprocessedCount) unprocessed.sendAll = sendAll.bind(unprocessed, fnName);
+
+      var errorCount = errors.filter(function(err) { return !!err; }).length;
+
+      callback(
+        errorCount ? errors : null,
+        data,
+        unprocessedCount ? unprocessed : null
+      );
     });
   }
 
@@ -105,7 +131,7 @@ module.exports = function(client) {
       return client.batchWrite(params);
     });
 
-    results.sendAll = sendAll.bind(null, results);
+    results.sendAll = sendAll.bind(null, results, 'batchWrite');
     return results;
   };
 
@@ -144,7 +170,7 @@ module.exports = function(client) {
       return client.batchGet(params);
     });
 
-    results.sendAll = sendAll.bind(null, results);
+    results.sendAll = sendAll.bind(null, results, 'batchGet');
     return results;
   };
 

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -1,22 +1,58 @@
 var big = require('big.js');
 var converter = require('aws-sdk/lib/dynamodb/converter');
 var queue = require('queue-async');
-
-function sendAll(requests, concurrency, callback) {
-  if (typeof concurrency === 'function') {
-    callback = concurrency;
-    concurrency = 1;
-  }
-
-  var q = queue(concurrency);
-  requests.forEach(function(req) {
-    q.defer(req.send.bind(req));
-  });
-  q.awaitAll(callback);
-}
+var _ = require('underscore');
 
 module.exports = function(client) {
   var requests = {};
+
+  function sendAll(requests, concurrency, callback) {
+    if (typeof concurrency === 'function') {
+      callback = concurrency;
+      concurrency = 1;
+    }
+
+    var q = queue(concurrency);
+
+    requests.forEach(function(req) {
+      q.defer(function(next) {
+        req.on('complete', function(response) {
+          next(null, response);
+        }).send();
+      });
+    });
+
+    q.awaitAll(function(err, responses) {
+      if (err) return callback(err);
+
+      var errors = [];
+      var data = [];
+      responses.forEach(function(response) {
+        errors.push(response.error);
+        data.push(response.data);
+      });
+
+      var unprocessed = data.reduce(function(unprocessed, data) {
+        if (data.UnprocessedItems) {
+          _(data.UnprocessedItems).each(function(items, table) {
+            unprocessed.RequestItems[table] = unprocessed.RequestItems[table] ?
+              unprocessed.RequestItems[table].concat(items) : items;
+          });
+        }
+        return unprocessed;
+      }, { RequestItems: {} });
+
+      unprocessed = Object.keys(unprocessed.RequestItems).length ?
+        requests.batchWriteItemRequests(unprocessed) : undefined;
+
+      errors = errors.reduce(function(errors, err) {
+        if (err) errors = errors ? errors.concat([err]) : [err];
+        return errors;
+      });
+
+      callback(errors, data, unprocessed);
+    });
+  }
 
   requests.batchWriteItemRequests = function(params) {
     var maxSize = 16 * 1024 * 1024;


### PR DESCRIPTION
The potential for `UnprocessedItems` in batch responses is tricky, especially if you need to make a set of requests. This branch sketches out consolidating some of the logic in dyno. The idea is:

1. `dyno.batchWriteItemRequests(params)` lets you hand in > 100 items to write. The function returns an array of unsent requests with a `.sendAll()` method attached.
2. The caller can then handle sending the requests themselves, or
3. use `.sendAll([concurrency], callback)` to ask dyno to send the requests. Concurrency defaults to 1. This **always sends all the requests** before firing the callback function, even if one of the requests fails. 
4. The callback function fires with three arguments:
    - `err`: **null** if there were no errors, otherwise **an array** of error objects with the same length as the number of requests that were sent. If a request succeeded, its index in the error array will be `undefined`
    - `data`: an array of responses to successful requests. If any requests failed, their index in the array will be `undefined`
    - `unprocessed`: `undefined` if there were no unprocessed items, otherwise another array of unsent requests with a `.sendAll()` function attached.

Important to keep in mind that UnprocessedItems are returned **as part of successful requests that don't throw any errors**. I think this flow keeps things separated in a way that makes sense. Usage might look something like this:

```js
var requestSet = dynamodb.dyno.batchWriteItemRequests(params);

(function sendRequests(requests) {
  requests.sendAll(10, function(err, responses, unprocessed) {
    if (err) {
      // "Handling" errors could mean retrying requests
      err.forEach(function(error, i) {
        var failedRequest = requestSet[i];
        failedRequest.send(retryHandlingFn);
      });
    }

    if (unprocessed) return sendRequests(unprocessed);
    console.log('everything was done successfully');
  });
})(requestSet);
```

Penny for your thoughts on this @mick @willwhite @jakepruitt. I ran into this right away as I started investigating using dyno v1 in downstream apps.