### PR TITLE
Sets must always be typed

### DIFF
--- a/index.js
+++ b/index.js
@@ -344,7 +344,15 @@ Dyno.multi = function(readOptions, writeOptions) {
  */
 Dyno.createSet = function(list) {
   var DynamoDBSet = require('aws-sdk/lib/dynamodb/set');
-  return new DynamoDBSet(list);
+  var set = new DynamoDBSet(list);
+
+  // hotfix for https://github.com/aws/aws-sdk-js/issues/801
+  if (!set.type) {
+    var typeOf = require('aws-sdk/lib/dynamodb/types').typeOf;
+    set.type = typeOf(list[0]);
+  }
+
+  return set;
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var AWS = require('aws-sdk');
+var DynamoDBSet = require('aws-sdk/lib/dynamodb/set');
 var _ = require('underscore');
 
 module.exports = Dyno;
@@ -343,16 +344,7 @@ Dyno.multi = function(readOptions, writeOptions) {
  * };
  */
 Dyno.createSet = function(list) {
-  var DynamoDBSet = require('aws-sdk/lib/dynamodb/set');
-  var set = new DynamoDBSet(list);
-
-  // hotfix for https://github.com/aws/aws-sdk-js/issues/801
-  if (!set.type) {
-    var typeOf = require('aws-sdk/lib/dynamodb/types').typeOf;
-    set.type = typeOf(list[0]);
-  }
-
-  return set;
+  return new DynamoDBSet(list);
 };
 
 /**

--- a/lib/serialization.js
+++ b/lib/serialization.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var converter = require('aws-sdk/lib/dynamodb/converter');
+var DynamoDBSet = require('aws-sdk/lib/dynamodb/set');
 
 module.exports.serialize = function(item) {
   function replacer(key, value) {
@@ -48,7 +49,15 @@ module.exports.deserialize = function(str) {
 
   var obj = JSON.parse(str, reviver);
   return Object.keys(obj).reduce(function(item, key) {
-    item[key] = converter.output(obj[key]);
+    var value = converter.output(obj[key]);
+
+    // hotfix for https://github.com/aws/aws-sdk-js/issues/801
+    if (value instanceof DynamoDBSet && !value.type) {
+      var typeOf = require('aws-sdk/lib/dynamodb/types').typeOf;
+      value.type = typeOf(value.values[0]);
+    }
+
+    item[key] = value;
     return item;
   }, {});
 };

--- a/lib/serialization.js
+++ b/lib/serialization.js
@@ -1,6 +1,5 @@
 var _ = require('underscore');
 var converter = require('aws-sdk/lib/dynamodb/converter');
-var DynamoDBSet = require('aws-sdk/lib/dynamodb/set');
 
 module.exports.serialize = function(item) {
   function replacer(key, value) {
@@ -50,13 +49,6 @@ module.exports.deserialize = function(str) {
   var obj = JSON.parse(str, reviver);
   return Object.keys(obj).reduce(function(item, key) {
     var value = converter.output(obj[key]);
-
-    // hotfix for https://github.com/aws/aws-sdk-js/issues/801
-    if (value instanceof DynamoDBSet && !value.type) {
-      var typeOf = require('aws-sdk/lib/dynamodb/types').typeOf;
-      value.type = typeOf(value.values[0]);
-    }
-
     item[key] = value;
     return item;
   }, {});

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Mick Thompson <mick@mick.im>",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "https://github.com/aws/aws-sdk-js/tarball/master",
+    "aws-sdk": "^2.2.18",
     "big.js": "^3.1.3",
     "event-stream": "^3.3.2",
     "minimist": "^1.1.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -107,6 +107,19 @@ test('[index] module exposes static functions', function(assert) {
   assert.end();
 });
 
+test('[index] Dyno.createSet always yields a typed set', function(assert) {
+  var convert = require('aws-sdk/lib/dynamodb/converter').input;
+
+  assert.equal(Dyno.createSet(['a', 'b']).type, 'String', 'sets string type');
+  assert.equal(Dyno.createSet([1, 2]).type, 'Number', 'sets number type');
+  assert.equal(Dyno.createSet([new Buffer('hello')]).type, 'Binary', 'sets buffer type');
+  assert.equal(Dyno.createSet(['']).type, 'String', 'sets string type on falsy value');
+  assert.equal(Dyno.createSet([0]).type, 'Number', 'sets number type on falsy value');
+  assert.deepEqual(convert(Dyno.createSet([0])), { NS: [ '0' ] }, 'set with falsy number value converts to appropriate wire-formatted object');
+  assert.deepEqual(convert(Dyno.createSet([''])), { SS: [ '' ] }, 'set with falsy string value converts to appropriate wire-formatted object');
+  assert.end();
+});
+
 test('[index] configuration', function(assert) {
   var config = {
     table: 'my-table',

--- a/test/serialization.test.js
+++ b/test/serialization.test.js
@@ -157,3 +157,15 @@ test('[serialization]', function(assert) {
 
   assert.end();
 });
+
+test('[serialization] deserialize string containing falsy set', function(assert) {
+  var str = JSON.stringify({ set: { NS: [0] } });
+  var obj = Dyno.deserialize(str);
+  assert.deepEqual(obj, {
+    set: {
+      type: 'Number',
+      values: [0]
+    }
+  }, 'success');
+  assert.end();
+});


### PR DESCRIPTION
Dyno utilizes a Set shim object provided by the aws-sdk. The shim has a bug (https://github.com/aws/aws-sdk-js/issues/801): when the first entry in the provided list is falsy (i.e. `''` or `0`), the set object has no `.type` property attached. 

When the aws-sdk document client sees this un-typed set in the process of constructing a DynamoDB request, it fails, leading to a request with invalid parameters that fails validation.

This PR is a hotfix right now for a couple of places where dyno encounters this problem explicitly. However it is by no means a complete solution. That'll need to wait for an upstream fix. Leaving this open until that arrives.