### PR TITLE
Roundtrip cli export --> import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.1 (in-progress)
+
+- fixes a bug in the cli which prevented export --> import roundtrips
+
 ## v1.1.0
 
 - adds `dyno.putStream()`, a writable stream to batch individual records into `BatchWriteItem` requests

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -84,8 +84,18 @@ function Parser() {
   parser._writableState.objectMode = false;
   parser._readableState.objectMode = true;
 
+  var firstline = true;
   parser._transform = function(record, enc, callback) {
     if (!record || record.length === 0) return;
+
+    if (firstline) {
+      firstline = false;
+
+      var parsed = Dyno.deserialize(record);
+      if (!Object.keys(parsed).every(function(key) {
+        return !!parsed[key];
+      })) return this.push(JSON.parse(record.toString()));
+    }
 
     record = Dyno.deserialize(record);
 


### PR DESCRIPTION
There was an issue with the CLI parser dropping attributes from the first line of the `export` output which defines the table's properties that should be imported.

Fixes #96 