### PR TITLE
batchGetAll and batchWriteAll to retry unprocessed

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,6 +2,17 @@
 
 A dyno client which extends the [aws-sdk's DocumentClient](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html).
 
+## batchGetAll
+
+Break a large batch of get operations into a set of requests that are intended
+to be sent concurrently.
+
+**Parameters**
+
+-   `params` **object** unbounded batchGetItem request parameters. See [DocumentClient.batchGet](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#batchGet-property) for details.
+
+Returns **CompleteRequestSet** 
+
 ## batchGetItem
 
 Perform a batch of get operations. Passthrough to [DocumentClient.batchGet](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#batchGet-property).
@@ -23,6 +34,17 @@ sent individually or concurrently.
 -   `params` **object** unbounded batchGetItem request parameters. See [DocumentClient.batchGet](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#batchGet-property) for details.
 
 Returns **RequestSet** 
+
+## batchWriteAll
+
+Break a large batch of write operations into a set of requests that are intended
+to be sent concurrently.
+
+**Parameters**
+
+-   `params` **object** unbounded batchWriteItem request parameters. See [DocumentClient.batchWrite](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#batchWrite-property) for details.
+
+Returns **CompleteRequestSet** 
 
 ## batchWriteItem
 
@@ -186,6 +208,27 @@ Update a single record. Passthrough to [DocumentClient.update](http://docs.aws.a
 
 Returns **Request** 
 
+# CompleteRequestSet
+
+An array of [AWS.Requests](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Request.html)
+
+## sendAll
+
+Send all the requests in a set, optionally specifying concurrency. This function
+will retry unprocessed items and return a single response body aggregated from
+results of all the individual requests.
+
+The callback function will be passed a single error object if any occurred, and the
+aggregated response body. If all requests encountered an error, the second argument
+will be null. Otherwise the callback may be provided with an error as well as
+the outcome from successful requests.
+
+**Parameters**
+
+-   `concurrency` **[number]** the concurrency with which to make requests.
+    Default value is `1`.
+-   `callback` **function** a function to handle the response.
+
 # Dyno
 
 Creates a dyno client. You must provide a table name and the region where the
@@ -336,6 +379,16 @@ DynamoDB record.
     the aggregate of all requests that have completed. This property will only
     be present if the `ReturnConsumedCapacity` parameter was set on the initial
     request.
+
+# reduceCapacity
+
+Reduce two sets of consumed capacity metrics into a single object
+
+**Parameters**
+
+-   `existing` **object** capacity. This object will be updated.
+-   `new` **object** capacity object to be added to the existing object.
+-   `incoming`  
 
 # Request
 

--- a/index.js
+++ b/index.js
@@ -192,6 +192,30 @@ function Dyno(options) {
    * @param {function} callback - a function to handle the response.
    */
 
+  /**
+   * An array of [AWS.Requests](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Request.html)
+   *
+   * @name CompleteRequestSet
+   */
+
+  /**
+   * Send all the requests in a set, optionally specifying concurrency. This function
+   * will retry unprocessed items and return a single response body aggregated from
+   * results of all the individual requests.
+   *
+   * The callback function will be passed a single error object if any occurred, and the
+   * aggregated response body. If all requests encountered an error, the second argument
+   * will be null. Otherwise the callback may be provided with an error as well as
+   * the outcome from successful requests.
+   *
+   * @name sendAll
+   * @instance
+   * @memberof CompleteRequestSet
+   * @param {number} [concurrency] - the concurrency with which to make requests.
+   * Default value is `1`.
+   * @param {function} callback - a function to handle the response.
+   */
+
   var dynoExtensions = {
     /**
      * Break a large batch of get operations into a set of requests that can be
@@ -213,6 +237,26 @@ function Dyno(options) {
      * @returns {RequestSet}
      */
     batchWriteItemRequests: require('./lib/requests')(docClient).batchWriteItemRequests,
+    /**
+     * Break a large batch of get operations into a set of requests that are intended
+     * to be sent concurrently.
+     *
+     * @instance
+     * @memberof client
+     * @param {object} params - unbounded batchGetItem request parameters. See [DocumentClient.batchGet](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#batchGet-property) for details.
+     * @returns {CompleteRequestSet}
+     */
+    batchGetAll: require('./lib/requests')(docClient).batchGetAll,
+    /**
+     * Break a large batch of write operations into a set of requests that are intended
+     * to be sent concurrently.
+     *
+     * @instance
+     * @memberof client
+     * @param {object} params - unbounded batchWriteItem request parameters. See [DocumentClient.batchWrite](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#batchWrite-property) for details.
+     * @returns {CompleteRequestSet}
+     */
+    batchWriteAll: require('./lib/requests')(docClient).batchWriteAll,
     /**
      * Create a table. Passthrough to [DynamoDB.createTable](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property),
      * except the function polls DynamoDB until the table is ready to accept
@@ -304,6 +348,7 @@ function Dyno(options) {
     delete nativeFunctions.updateItem;
     delete nativeFunctions.batchWriteItem;
     delete dynoExtensions.batchWriteItemRequests;
+    delete dynoExtensions.batchWriteAll;
     delete dynoExtensions.putStream;
   }
 
@@ -313,6 +358,7 @@ function Dyno(options) {
     delete dynoExtensions.query;
     delete dynoExtensions.scan;
     delete dynoExtensions.batchGetItemRequests;
+    delete dynoExtensions.batchGetAll;
     delete dynoExtensions.queryStream;
     delete dynoExtensions.scanStream;
   }

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -1,6 +1,7 @@
 var big = require('big.js');
 var converter = require('aws-sdk/lib/dynamodb/converter');
 var queue = require('queue-async');
+var reduceCapacity = require('./util').reduceCapacity;
 
 module.exports = function(client) {
   var requests = {};
@@ -78,6 +79,94 @@ module.exports = function(client) {
     });
   }
 
+  /**
+   * Given a set of requests, this function sends them all at specified concurrency,
+   * retrying any unprocessed items until every request has either succeeded or failed.
+   * The responses from the set of requests are aggregated into a single response.
+   * Generally, this function is not called directly, but is bound to an array of
+   * requests with the first two parameters wired to specific values.
+   *
+   * @private
+   * @param {RequestSet} requests - an array of AWS.Request objects
+   * @param {string} fnName - the name of the aws-sdk client function that will
+   * be used to construct new requests should an unprocessed items be detected
+   * @param {number} concurrency - the concurrency with which batch requests
+   * will be made
+   * @param {function} callback - a function to handle the response
+   */
+  function sendCompletely(requests, fnName, concurrency, callback) {
+    if (typeof concurrency === 'function') {
+      callback = concurrency;
+      concurrency = 1;
+    }
+
+    function sendOne(req, callback) {
+      if (!req) return callback();
+      var result = { error: undefined, data: { Responses: {}, ConsumedCapacity: undefined } };
+
+      (function send(req) {
+        req.on('complete', function(response) {
+          if (!response.data) {
+            result.error = response.error;
+            return callback(null, result);
+          }
+
+          Object.keys(response.data.Responses).forEach(function(table) {
+            result.data.Responses[table] = result.data.Responses[table] || [];
+            response.data.Responses[table].forEach(function(res) {
+              result.data.Responses[table].push(res);
+            });
+          });
+
+          if (response.data.ConsumedCapacity) {
+            result.data.ConsumedCapacity = result.data.ConsumedCapacity || {};
+            reduceCapacity(result.data.ConsumedCapacity, response.data.ConsumedCapacity);
+          }
+
+          var newParams = {
+            RequestItems: response.data.UnprocessedItems || response.data.UnprocessedKeys,
+            ReturnConsumedCapacity: req.params.ReturnConsumedCapacity
+          };
+
+          if (newParams.RequestItems && Object.keys(newParams.RequestItems).length) {
+            return send(client[fnName](newParams));
+          }
+
+          callback(null, result);
+        }).send();
+      })(req);
+    }
+
+    var q = queue(concurrency);
+
+    requests.forEach(function(req) {
+      q.defer(sendOne, req);
+    });
+
+    q.awaitAll(function(_, responses) {
+      var err;
+      var result = { Responses: {}, ConsumedCapacity: undefined };
+      responses.forEach(function(res) {
+        if (res.error) err = res.error;
+
+        Object.keys(res.data.Responses).forEach(function(table) {
+          result.Responses[table] = result.Responses[table] || [];
+          res.data.Responses[table].forEach(function(r) {
+            result.Responses[table].push(r);
+          });
+        });
+
+        if (res.data.ConsumedCapacity) {
+          result.ConsumedCapacity = result.ConsumedCapacity || {};
+          reduceCapacity(result.ConsumedCapacity, res.data.ConsumedCapacity);
+        }
+      });
+
+      if (err && !Object.keys(result.Responses).length) return callback(err);
+      callback(err, result);
+    });
+  }
+
   requests.batchWriteItemRequests = function(params) {
     var maxSize = 16 * 1024 * 1024;
 
@@ -120,10 +209,10 @@ module.exports = function(client) {
         if (!requestsToMake.length) return paramSet;
 
         // otherwise start a new request set
-        paramSet.push({ RequestItems: {} });
+        paramSet.push({ RequestItems: {}, ReturnConsumedCapacity: params.ReturnConsumedCapacity });
         return chop(requestsToMake);
       }
-    }, [{ RequestItems: {} }]);
+    }, [{ RequestItems: {}, ReturnConsumedCapacity: params.ReturnConsumedCapacity }]);
 
     var results = paramSet.map(function(params) {
       return client.batchWrite(params);
@@ -159,10 +248,10 @@ module.exports = function(client) {
         if (!requestsToMake.length) return paramSet;
 
         // otherwise start a new request set
-        paramSet.push({ RequestItems: {} });
+        paramSet.push({ RequestItems: {}, ReturnConsumedCapacity: params.ReturnConsumedCapacity });
         return chop(requestsToMake);
       }
-    }, [{ RequestItems: {} }]);
+    }, [{ RequestItems: {}, ReturnConsumedCapacity: params.ReturnConsumedCapacity }]);
 
     var results = paramSet.map(function(params) {
       return client.batchGet(params);
@@ -170,6 +259,18 @@ module.exports = function(client) {
 
     results.sendAll = sendAll.bind(null, results, 'batchGet');
     return results;
+  };
+
+  requests.batchWriteAll = function(params) {
+    var requestSet = requests.batchWriteItemRequests(params);
+    requestSet.sendAll = sendCompletely.bind(null, requestSet, 'batchWrite');
+    return requestSet;
+  };
+
+  requests.batchGetAll = function(params) {
+    var requestSet = requests.batchGetItemRequests(params);
+    requestSet.sendAll = sendCompletely.bind(null, requestSet, 'batchGet');
+    return requestSet;
   };
 
   return requests;

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -102,7 +102,7 @@ module.exports = function(client) {
 
     function sendOne(req, callback) {
       if (!req) return callback();
-      var result = { error: undefined, data: { Responses: {}, ConsumedCapacity: undefined } };
+      var result = { error: undefined, data: {} };
 
       (function send(req) {
         req.on('complete', function(response) {
@@ -111,12 +111,15 @@ module.exports = function(client) {
             return callback(null, result);
           }
 
-          Object.keys(response.data.Responses).forEach(function(table) {
-            result.data.Responses[table] = result.data.Responses[table] || [];
-            response.data.Responses[table].forEach(function(res) {
-              result.data.Responses[table].push(res);
+          if (response.data.Responses) {
+            result.data.Responses = result.data.Responses || {};
+            Object.keys(response.data.Responses).forEach(function(table) {
+              result.data.Responses[table] = result.data.Responses[table] || [];
+              response.data.Responses[table].forEach(function(res) {
+                result.data.Responses[table].push(res);
+              });
             });
-          });
+          }
 
           if (response.data.ConsumedCapacity) {
             result.data.ConsumedCapacity = result.data.ConsumedCapacity || {};
@@ -145,16 +148,19 @@ module.exports = function(client) {
 
     q.awaitAll(function(_, responses) {
       var err;
-      var result = { Responses: {}, ConsumedCapacity: undefined };
+      var result = { };
       responses.forEach(function(res) {
         if (res.error) err = res.error;
 
-        Object.keys(res.data.Responses).forEach(function(table) {
-          result.Responses[table] = result.Responses[table] || [];
-          res.data.Responses[table].forEach(function(r) {
-            result.Responses[table].push(r);
+        if (res.data.Responses) {
+          result.Responses = result.Responses || {};
+          Object.keys(res.data.Responses).forEach(function(table) {
+            result.Responses[table] = result.Responses[table] || [];
+            res.data.Responses[table].forEach(function(r) {
+              result.Responses[table].push(r);
+            });
           });
-        });
+        }
 
         if (res.data.ConsumedCapacity) {
           result.ConsumedCapacity = result.ConsumedCapacity || {};

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,33 +1,7 @@
 var Readable = require('stream').Readable;
 var _ = require('underscore');
 var parallel = require('parallel-stream');
-
-function reduceCapacity(existing, incoming) {
-  existing = existing || {};
-  existing.TableName = existing.TableName || incoming.TableName;
-
-  if (incoming.CapacityUnits) {
-    existing.CapacityUnits = (existing.CapacityUnits || 0) + incoming.CapacityUnits;
-  }
-
-  if (incoming.Table) {
-    existing.Table = existing.Table ?
-      { CapacityUnits: existing.Table.CapacityUnits + incoming.Table.CapacityUnits } :
-      { CapacityUnits: incoming.Table.CapacityUnits };
-  }
-
-  if (incoming.LocalSecondaryIndexes) {
-    existing.LocalSecondaryIndexes = existing.LocalSecondaryIndexes ?
-      { CapacityUnits: existing.LocalSecondaryIndexes.CapacityUnits + incoming.LocalSecondaryIndexes.CapacityUnits } :
-      { CapacityUnits: incoming.LocalSecondaryIndexes.CapacityUnits };
-  }
-
-  if (incoming.GlobalSecondaryIndexes) {
-    existing.GlobalSecondaryIndexes = existing.GlobalSecondaryIndexes ?
-      { CapacityUnits: existing.GlobalSecondaryIndexes.CapacityUnits + incoming.GlobalSecondaryIndexes.CapacityUnits } :
-      { CapacityUnits: incoming.GlobalSecondaryIndexes.CapacityUnits };
-  }
-}
+var reduceCapacity = require('./util').reduceCapacity;
 
 module.exports = function(client, tableName) {
   var stream = {};

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,32 @@
+/**
+ * Reduce two sets of consumed capacity metrics into a single object
+ *
+ * @param {object} existing capacity. This object will be updated.
+ * @param {object} new capacity object to be added to the existing object.
+ */
+module.exports.reduceCapacity = function(existing, incoming) {
+  existing = existing || {};
+  existing.TableName = existing.TableName || incoming.TableName;
+
+  if (incoming.CapacityUnits) {
+    existing.CapacityUnits = (existing.CapacityUnits || 0) + incoming.CapacityUnits;
+  }
+
+  if (incoming.Table) {
+    existing.Table = existing.Table ?
+      { CapacityUnits: existing.Table.CapacityUnits + incoming.Table.CapacityUnits } :
+      { CapacityUnits: incoming.Table.CapacityUnits };
+  }
+
+  if (incoming.LocalSecondaryIndexes) {
+    existing.LocalSecondaryIndexes = existing.LocalSecondaryIndexes ?
+      { CapacityUnits: existing.LocalSecondaryIndexes.CapacityUnits + incoming.LocalSecondaryIndexes.CapacityUnits } :
+      { CapacityUnits: incoming.LocalSecondaryIndexes.CapacityUnits };
+  }
+
+  if (incoming.GlobalSecondaryIndexes) {
+    existing.GlobalSecondaryIndexes = existing.GlobalSecondaryIndexes ?
+      { CapacityUnits: existing.GlobalSecondaryIndexes.CapacityUnits + incoming.GlobalSecondaryIndexes.CapacityUnits } :
+      { CapacityUnits: incoming.GlobalSecondaryIndexes.CapacityUnits };
+  }
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,6 +29,8 @@ test('[index] expected properties', function(assert) {
   assert.equal(typeof dyno.updateItem, 'function', 'exposes updateItem function');
   assert.equal(typeof dyno.batchGetItemRequests, 'function', 'exposes batchGetItemRequests function');
   assert.equal(typeof dyno.batchWriteItemRequests, 'function', 'exposes batchWriteItemRequests function');
+  assert.equal(typeof dyno.batchGetAll, 'function', 'exposes batchGetAll function');
+  assert.equal(typeof dyno.batchWriteAll, 'function', 'exposes batchWriteAll function');
   assert.equal(typeof dyno.createTable, 'function', 'exposes createTable function');
   assert.equal(typeof dyno.deleteTable, 'function', 'exposes deleteTable function');
   assert.equal(typeof dyno.queryStream, 'function', 'exposes queryStream function');
@@ -50,6 +52,8 @@ test('[index] expected properties', function(assert) {
   assert.equal(typeof read.updateItem, 'undefined', 'read-only client does not expose updateItem function');
   assert.equal(typeof read.batchGetItemRequests, 'function', 'read-only client exposes batchGetItemRequests function');
   assert.equal(typeof read.batchWriteItemRequests, 'undefined', 'read-only client does not expose batchWriteItemRequests function');
+  assert.equal(typeof read.batchGetAll, 'function', 'read-only client exposes batchGetAll function');
+  assert.equal(typeof read.batchWriteAll, 'undefined', 'read-only client does not expose batchWriteAll function');
   assert.equal(typeof read.createTable, 'function', 'read-only client exposes createTable function');
   assert.equal(typeof read.deleteTable, 'function', 'read-only client exposes deleteTable function');
   assert.equal(typeof read.queryStream, 'function', 'read-only client exposes queryStream function');
@@ -71,6 +75,8 @@ test('[index] expected properties', function(assert) {
   assert.equal(typeof write.updateItem, 'function', 'write-only client exposes updateItem function');
   assert.equal(typeof write.batchGetItemRequests, 'undefined', 'write-only client does not expose batchGetItemRequests function');
   assert.equal(typeof write.batchWriteItemRequests, 'function', 'write-only client exposes batchWriteItemRequests function');
+  assert.equal(typeof write.batchGetAll, 'undefined', 'write-only client does not expose batchGetAll function');
+  assert.equal(typeof write.batchWriteAll, 'function', 'write-only client exposes batchWriteAll function');
   assert.equal(typeof write.createTable, 'function', 'write-only client exposes createTable function');
   assert.equal(typeof write.deleteTable, 'function', 'write-only client exposes deleteTable function');
   assert.equal(typeof write.queryStream, 'undefined', 'write-only client does not expose queryStream function');
@@ -95,6 +101,8 @@ test('[index] expected properties', function(assert) {
   assert.equal(typeof multi.updateItem, 'function', 'multi-client exposes updateItem function');
   assert.equal(typeof multi.batchGetItemRequests, 'function', 'exposes batchGetItemRequests function');
   assert.equal(typeof multi.batchWriteItemRequests, 'function', 'exposes batchWriteItemRequests function');
+  assert.equal(typeof multi.batchGetAll, 'function', 'exposes batchGetAll function');
+  assert.equal(typeof multi.batchWriteAll, 'function', 'exposes batchWriteAll function');
   assert.equal(typeof multi.createTable, 'function', 'multi-client exposes createTable function');
   assert.equal(typeof multi.deleteTable, 'function', 'multi-client exposes deleteTable function');
   assert.equal(typeof multi.queryStream, 'function', 'multi-client exposes queryStream function');


### PR DESCRIPTION
Adds new functions to handle multiple BatchWriteItem or BatchGetItem requests:

- follows the same pattern from `batchGetItemRequests` or `batchWriteItemRequests` where you

  ```js
  dyno.batchWriteAll(params).sendAll(10, callback);
  ```

- the `sendAll` implementation retries unprocessed items until there are none left.

- the callback from `sendAll` is given a single err object (even if multiple requests errored), and a single response object (or null if all requests errored). If any requests were successful, the response object is an aggregation of all the successful responses.

fixes #116 