### PR TITLE
Requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .nyc_output
 coverage/
+node_modules/

--- a/lib/requests.js
+++ b/lib/requests.js
@@ -177,7 +177,7 @@ module.exports = function(client) {
     });
 
     q.awaitAll(function(_, responses) {
-      var err;
+      var err, hasResponses;
       var result = { };
       responses.forEach(function(res) {
         if (res.error) err = res.error;
@@ -218,7 +218,8 @@ module.exports = function(client) {
         }
       });
 
-      if (err && !Object.keys(result.Responses).length) return callback(err);
+      hasResponses = result.Responses && Object.keys(result.Responses).length;
+      if (err && !hasResponses) return callback(err);
       callback(err, result);
     });
   }


### PR DESCRIPTION
Thanks for creating `dyno` !

The error handling for `sendCompletely` first attempts to check if the `result` object includes a `Responses` object of any value prior to invoking the callback. However, in cases where this property is not present, such as with a `ValidationException` error, this check results in it's own uncaught `TypeError` and fails to ever invoke the callback.

This change allows for a safer `Responses` check so that an error may be passed back to the caller as expected.
