### PR TITLE
Handle bad data responses

### DIFF
--- a/lib/requests.js
+++ b/lib/requests.js
@@ -218,7 +218,6 @@ module.exports = function(client) {
         }
       });
 
-      if (err && !Object.keys(result.Responses).length) return callback(err);
       callback(err, result);
     });
   }

--- a/test/requests.test.js
+++ b/test/requests.test.js
@@ -841,6 +841,49 @@ test('[requests] batchWriteAll sendAll: everything is unprocessed. timeout', fun
   });
 });
 
+test('[requests] batchWriteAll sendAll: no data.Response', function(assert) {
+  var original = AWS.Request.prototype.send;
+
+  AWS.Request.prototype.send = function() {
+    var error = new Error('omg! mock error!');
+    error.statusCode = 404;
+
+    this.removeListener('extractError', AWS.EventListeners.Core.EXTRACT_ERROR);
+    this.on('extractError', function(response) { response.error = error; });
+
+    this.removeListener('extractData', AWS.EventListeners.Core.EXTRACT_DATA);
+    this.on('extractData', function(response) { response.data = {}; });
+
+    this.removeListener('send', AWS.EventListeners.Core.SEND);
+    this.on('send', function(response) {
+      response.httpResponse.body = '{"mocked":"response"}';
+      response.httpResponse.statusCode = 404;
+    });
+
+    this.runTo();
+    return this.response;
+  };
+
+  var dyno = Dyno({
+    table: dynamodb.tableName,
+    region: 'local',
+    endpoint: 'http://localhost:4567'
+  });
+
+  var params = { RequestItems: {}, ReturnConsumedCapacity: 'TOTAL' };
+  params.RequestItems[dynamodb.tableName] = fixtures.map(function(item) {
+    return { PutRequest: { Item: item } };
+  });
+
+  var requests = dyno.batchWriteAll(params, 3);
+  requests.sendAll(function(err, data) {
+    assert.ok(err);
+    assert.ok(!data, 'no data passed');
+    AWS.Request.prototype.send = original;
+    assert.end();
+  });
+});
+
 second.delete();
 dynamodb.delete();
 

--- a/test/requests.test.js
+++ b/test/requests.test.js
@@ -876,9 +876,8 @@ test('[requests] batchWriteAll sendAll: no data.Response', function(assert) {
   });
 
   var requests = dyno.batchWriteAll(params, 3);
-  requests.sendAll(function(err, data) {
+  requests.sendAll(function(err) {
     assert.ok(err);
-    assert.ok(!data, 'no data passed');
     AWS.Request.prototype.send = original;
     assert.end();
   });


### PR DESCRIPTION
Handle a condition where `data.Responses` is not defined by `aws-sdk-js`. It's not 100% clear to me what the underlying condition for this to happen is (echoes of https://github.com/mapbox/s3scan/issues/17) -- we'll learn more by catching and handling this case correctly.

cc @rclark 