### PR TITLE
Add backoff to queryStream, scanStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .nyc_output
 coverage/
+/node_modules/

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -9,23 +9,40 @@ module.exports = function(client, tableName) {
   function readableStream(request, params, options) {
     options = options || {};
     var pages = options.pages || Infinity;
+    var maxRetries = options.maxRetries || Infinity;
 
     var readable = new Readable(_({ objectMode: true }).defaults(options));
-    var nextRequest = client[request](params);
+    var nextRequestFn = client[request].bind(client, params);
     var pending = false;
     var items = [];
+    var retries = 0;
 
     readable.Count = 0;
     readable.ScannedCount = 0;
 
-    function makeRequest(request) {
+    function makeRequest(requestFn) {
       pending = true;
 
-      request
+      requestFn()
         .on('validate', function(req) { readable.emit('validate', req); })
-        .on('error', function(err) { readable.emit('error', err); })
+        .on('error', function(err) {
+          if (!(err.code === 'ProvisionedThroughputExceededException' || err.code === 'ThrottlingException')) {
+            readable.emit('error', err);
+          } else {
+            retries++;
+            if (retries > maxRetries) {
+              readable.emit('error', err);
+            } else {
+              var retryDelay = Math.min(60000, 100 * Math.pow(2, retries));
+              setTimeout(function () {
+                makeRequest(requestFn);
+              }, retryDelay);
+            }
+          }
+        })
         .on('success', function(response) {
           pending = false;
+          retries = 0;
 
           readable.Count += response.data.Count;
           readable.ScannedCount += response.data.ScannedCount;
@@ -37,7 +54,7 @@ module.exports = function(client, tableName) {
           }
 
           pages--;
-          nextRequest = pages && response.hasNextPage() ? response.nextPage() : false;
+          nextRequestFn = pages && response.hasNextPage() ? response.nextPage.bind(response) : false;
 
           response.data.Items.forEach(function(item) { items.push(item); });
           readable._read();
@@ -48,8 +65,8 @@ module.exports = function(client, tableName) {
       var status = true;
       while (status && items.length) status = readable.push(items.shift());
       if (items.length) return;
-      if (!nextRequest) return readable.push(null);
-      if (status && !pending) makeRequest(nextRequest);
+      if (!nextRequestFn) return readable.push(null);
+      if (status && !pending) makeRequest(nextRequestFn);
     };
 
     return readable;


### PR DESCRIPTION
A reasonable user of these streaming functions would expect them to stream
data as long as there is data (paging, already implemented), and at the rate
it can be fetched.

This commit takes the specific errors ProvisionedThroughputExceededException
and ThrottlingException, and handles them as signals to temporarily back off.

It starts retrying after 200 ms, then doubles that each time it retries
without a successful response, up to 60000 ms. Then it retries every 60000 ms.