### PR TITLE
Accept any 2.x aws-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Mick Thompson <mick@mick.im>",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.7.2",
+    "aws-sdk": "2.x",
     "big.js": "^3.1.3",
     "event-stream": "^3.3.2",
     "minimist": "^1.1.0",


### PR DESCRIPTION
This gets the aws-sdk version semver compatible between dyno and https://github.com/mapbox/cardboard/pull/187. This is desirable since aws-sdk is massive and adds a lot of weight to installs. Without this `npm dedupe` may fail to collapse the dupes.