### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.1
+
+- updates minimist dependency to v1.2.6 from v1.2.5
+
 ## v1.5.0
 
 - drop support for Node 6 & 8

--- a/package-lock.json
+++ b/package-lock.json
@@ -5436,9 +5436,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "aws-sdk": "^2.7.2",
     "big.js": "^3.1.3",
     "event-stream": "3.3.4",
-    "minimist": "^1.2.5",
+    "minimist": "^1.2.6",
     "parallel-stream": "^1.1.2",
     "queue-async": "~1.0.7",
     "underscore": "^1.13.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Simple DynamoDB client",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
Dependencies updated:

- `minimist`: `v1.2.5` -> `v1.2.6`

Changes in the updated dependencies:

- [`minimist`](https://github.com/substack/minimist/compare/1.2.5...1.2.6): Fixed a security vulnerability, no breaking changes detected.

Related to https://github.com/mapbox/billing-team/issues/2305.