### PR TITLE
Update reduceCapacity to support new data shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.5.2
+
+- update reduceCapacity to support new data shape [#157](https://github.com/mapbox/dyno/pull/157)
+
 ## v1.5.1
 
 - updates minimist dependency to v1.2.6 from v1.2.5

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,7 +23,7 @@ function reduceCapacity(existing, incoming) {
     if (src.CapacityUnits) {
       dst.CapacityUnits = (dst.CapacityUnits || 0) + src.CapacityUnits;
     }
-    if (src.CapacityUnits) {
+    if (src.ReadCapacityUnits) {
       dst.ReadCapacityUnits = (dst.ReadCapacityUnits || 0) + src.ReadCapacityUnits;
     }
     if (src.WriteCapacityUnits) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,6 +1,8 @@
 /* eslint-env es6 */
 /**
  * Reduce two sets of consumed capacity metrics into a single object
+ * This should be in sync with Callback Parameters section of
+ * https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#query-property
  *
  * @param {object} existing capacity. This object will be updated.
  * @param {object | array} new capacity object(s) to be added to the existing object.
@@ -18,10 +20,15 @@ function reduceCapacity(existing, incoming) {
   }
 
   function mergeCapacityUnits(dst, src) {
-    if (!src.CapacityUnits) {
-      return;
+    if (src.CapacityUnits) {
+      dst.CapacityUnits = (dst.CapacityUnits || 0) + src.CapacityUnits;
     }
-    dst.CapacityUnits = (dst.CapacityUnits || 0) + src.CapacityUnits;
+    if (src.CapacityUnits) {
+      dst.ReadCapacityUnits = (dst.ReadCapacityUnits || 0) + src.ReadCapacityUnits;
+    }
+    if (src.WriteCapacityUnits) {
+      dst.WriteCapacityUnits = (dst.WriteCapacityUnits || 0) + src.WriteCapacityUnits;
+    }
   }
 
   function mergeCapacityParents(dst, src, k) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,32 +1,54 @@
+/* eslint-env es6 */
 /**
  * Reduce two sets of consumed capacity metrics into a single object
  *
  * @param {object} existing capacity. This object will be updated.
- * @param {object} new capacity object to be added to the existing object.
+ * @param {object | array} new capacity object(s) to be added to the existing object.
  */
-module.exports.reduceCapacity = function(existing, incoming) {
-  existing = existing || {};
+function reduceCapacity(existing, incoming) {
+  if (!existing) {
+    return;
+  }
+
+  if (Array.isArray(incoming)) {
+    for (const item of incoming) {
+      reduceCapacity(existing, item);
+    }
+    return;
+  }
+
+  function mergeCapacityUnits(dst, src) {
+    if (!src.CapacityUnits) {
+      return;
+    }
+    dst.CapacityUnits = (dst.CapacityUnits || 0) + src.CapacityUnits;
+  }
+
+  function mergeCapacityParents(dst, src, k) {
+    if (!src[k]) {
+      return;
+    }
+    dst[k] = dst[k] || {};
+    mergeCapacityUnits(dst[k], src[k]);
+  }
+
   existing.TableName = existing.TableName || incoming.TableName;
 
-  if (incoming.CapacityUnits) {
-    existing.CapacityUnits = (existing.CapacityUnits || 0) + incoming.CapacityUnits;
-  }
+  mergeCapacityUnits(existing, incoming);
+  mergeCapacityParents(existing, incoming, 'Table');
+  mergeCapacityParents(existing, incoming, 'LocalSecondaryIndexes');
+  mergeCapacityParents(existing, incoming, 'GlobalSecondaryIndexes');
 
-  if (incoming.Table) {
-    existing.Table = existing.Table ?
-      { CapacityUnits: existing.Table.CapacityUnits + incoming.Table.CapacityUnits } :
-      { CapacityUnits: incoming.Table.CapacityUnits };
+  for (const indexGroup of [
+    'LocalSecondaryIndexes',
+    'GlobalSecondaryIndexes',
+  ]) {
+    const dst = existing[indexGroup];
+    const src = incoming[indexGroup];
+    for (const index of Object.keys(src || {})) {
+      mergeCapacityParents(dst, src, index);
+    }
   }
+}
 
-  if (incoming.LocalSecondaryIndexes) {
-    existing.LocalSecondaryIndexes = existing.LocalSecondaryIndexes ?
-      { CapacityUnits: existing.LocalSecondaryIndexes.CapacityUnits + incoming.LocalSecondaryIndexes.CapacityUnits } :
-      { CapacityUnits: incoming.LocalSecondaryIndexes.CapacityUnits };
-  }
-
-  if (incoming.GlobalSecondaryIndexes) {
-    existing.GlobalSecondaryIndexes = existing.GlobalSecondaryIndexes ?
-      { CapacityUnits: existing.GlobalSecondaryIndexes.CapacityUnits + incoming.GlobalSecondaryIndexes.CapacityUnits } :
-      { CapacityUnits: incoming.GlobalSecondaryIndexes.CapacityUnits };
-  }
-};
+module.exports.reduceCapacity = reduceCapacity;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Simple DynamoDB client",
   "main": "index.js",
   "engines": {

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,59 @@
+/* eslint-env es6 */
+const test = require('tape');
+const reduceCapacity = require('../lib/util').reduceCapacity;
+
+test('[reduceCapacity] parses new data format correctly', function (assert) {
+  const src = [{
+    TableName: 'db-staging',
+    CapacityUnits: 8,
+    Table: { CapacityUnits: 4 },
+    GlobalSecondaryIndexes: { 'id-index': { CapacityUnits: 4 } }
+  }];
+  const dst = {};
+
+  reduceCapacity(dst, src);
+
+  assert.equal(dst.CapacityUnits, 8);
+  assert.equal(dst.Table.CapacityUnits, 4);
+  assert.equal(dst.GlobalSecondaryIndexes['id-index'].CapacityUnits, 4);
+  assert.end();
+});
+
+test('[reduceCapacity] parses old data format correctly', function (assert) {
+  const src = {
+    TableName: 'db-staging',
+    CapacityUnits: 8,
+    Table: { CapacityUnits: 4 },
+    GlobalSecondaryIndexes: { CapacityUnits: 4 }
+  };
+  const dst = {};
+
+  reduceCapacity(dst, src);
+
+  assert.equal(dst.CapacityUnits, 8);
+  assert.equal(dst.Table.CapacityUnits, 4);
+  assert.equal(dst.GlobalSecondaryIndexes.CapacityUnits, 4);
+  assert.end();
+});
+
+test('[reduceCapacity] merges old data format correctly', function (assert) {
+  const src = [{
+    TableName: 'db-staging',
+    CapacityUnits: 8,
+    Table: { CapacityUnits: 4 },
+    GlobalSecondaryIndexes: { 'id-index': { CapacityUnits: 4 } }
+  }];
+  const dst = {
+    CapacityUnits: 2,
+    Table: { CapacityUnits: 1 },
+    GlobalSecondaryIndexes: { 'di-index': { CapacityUnits: 4 } }
+  };
+
+  reduceCapacity(dst, src);
+
+  assert.equal(dst.CapacityUnits, 10);
+  assert.equal(dst.Table.CapacityUnits, 5);
+  assert.equal(dst.GlobalSecondaryIndexes['id-index'].CapacityUnits, 4);
+  assert.equal(dst.GlobalSecondaryIndexes['di-index'].CapacityUnits, 4);
+  assert.end();
+});

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -6,7 +6,9 @@ test('[reduceCapacity] parses new data format correctly', function (assert) {
   const src = [{
     TableName: 'db-staging',
     CapacityUnits: 8,
-    Table: { CapacityUnits: 4 },
+    ReadCapacityUnits: 3,
+    WriteCapacityUnits: 1,
+    Table: { CapacityUnits: 4, ReadCapacityUnits: 3, WriteCapacityUnits: 1 },
     GlobalSecondaryIndexes: { 'id-index': { CapacityUnits: 4 } }
   }];
   const dst = {};
@@ -55,5 +57,11 @@ test('[reduceCapacity] merges old data format correctly', function (assert) {
   assert.equal(dst.Table.CapacityUnits, 5);
   assert.equal(dst.GlobalSecondaryIndexes['id-index'].CapacityUnits, 4);
   assert.equal(dst.GlobalSecondaryIndexes['di-index'].CapacityUnits, 4);
+  assert.end();
+});
+
+
+test('[reduceCapacity] does not crash if dst is empty', function (assert) {
+  reduceCapacity(null, []);
   assert.end();
 });


### PR DESCRIPTION
When using batch operations the stats are not returned correctly.

For example, this request:

```js
batchWriteAll({
  RequestItems: { ... },
  ReturnConsumedCapacity: 'INDEXES',
  ReturnItemCollectionMetrics: 'SIZE'
})
```

causes AWS to return the following data structure:

```js
{
  ConsumedCapacity: [{
    TableName: 'table',
    CapacityUnits: 8,
    Table: { CapacityUnits: 4 },
    GlobalSecondaryIndexes: { index: { CapacityUnits: 4 } }
  }]
}
```

which is then transformed by `reduceCapacity` inside `sendAll` to this:

```js
{
  ConsumedCapacity: {
    TableName: undefined
  }
}
```

This PR fixes that problem.