### PR TITLE
Add costLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.6.0
 
-- Support to pass a `costLogger` which will be called with casted `ConsumedCapacity`
+- Support passing a `costLogger` which will be called with casted `ConsumedCapacity`
+- Support reusing DynamoDB Client by passing `dynoInstance` 
 
 ## v1.5.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.6.0
+
+- Support to pass a `costLogger` which will be called with casted `ConsumedCapacity`
+
 ## v1.5.2
 
 - update reduceCapacity to support new data shape [#157](https://github.com/mapbox/dyno/pull/157)

--- a/index.js
+++ b/index.js
@@ -160,7 +160,7 @@ function Dyno(options) {
      * @param {function} [callback] - a function to handle the response. See [DocumentClient.update](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#update-property) for details.
      * @returns {Request}
      */
-    updateItem: docClient.update,
+    updateItem: docClient.update
   };
 
   /**
@@ -382,7 +382,7 @@ Dyno.multi = function(readOptions, writeOptions) {
   return _({}).extend(write, read, {
     config: { read: read.config, write: write.config },
     createTable: require('./lib/table')(read, write).multiCreate,
-    deleteTable: require('./lib/table')(read, write).multiDelete,
+    deleteTable: require('./lib/table')(read, write).multiDelete
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
+/* eslint-env es6 */
 var AWS = require('aws-sdk');
 var DynamoDBSet = require('aws-sdk/lib/dynamodb/set');
 var _ = require('underscore');
-var util = require('./lib/util');
+const util = require('./lib/util');
 
 module.exports = Dyno;
 
@@ -60,11 +61,11 @@ function Dyno(options, dynoInstance) {
    * be present if the `ReturnConsumedCapacity` parameter was set on the initial
    * request.
    */
-  var client;
-  var docClient;
-  var tableFreeClient;
-  var tableFreeDocClient;
-  var config = {};
+  let client;
+  let docClient;
+  let tableFreeClient;
+  let tableFreeDocClient;
+  let config = {};
 
   // Reuse DynamoDB Client
   if (dynoInstance && dynoInstance.client) {
@@ -96,8 +97,8 @@ function Dyno(options, dynoInstance) {
 
   }
   
-  var wrappedDocClient = util.wrapDocClient(docClient, options.costLogger);
-  var wrappedTableFreeDocClient = util.wrapDocClient(tableFreeDocClient, options.costLogger);
+  const wrappedDocClient = util.wrapDocClient(docClient, options.costLogger);
+  const wrappedTableFreeDocClient = util.wrapDocClient(tableFreeDocClient, options.costLogger);
 
   // Straight-up inherit several functions from aws-sdk so we can also inherit docs and tests
   var nativeFunctions = {

--- a/index.js
+++ b/index.js
@@ -72,15 +72,15 @@ function Dyno(options) {
   let config = {};
 
   // Reuse DynamoDB Client
-  if (options.dynoInstance && options.dynoInstance.client) {
+  if (options.dynoInstance && options.dynoInstance._client) {
     const dynoInstance = options.dynoInstance;
     if (Object.keys(options).some(o => ['region', 'endpoint', 'table'].includes(o))) {
       throw new Error('No need to provide DynamoDB config when reusing Dynamodb client');
     }
-    client = dynoInstance.client;
-    docClient = dynoInstance.docClient;
-    tableFreeClient = dynoInstance.tableFreeClient;
-    tableFreeDocClient = dynoInstance.tableFreeDocClient;
+    client = dynoInstance._client;
+    docClient = dynoInstance._docClient;
+    tableFreeClient = dynoInstance._tableFreeClient;
+    tableFreeDocClient = dynoInstance._tableFreeDocClient;
     config = dynoInstance.config;
   } else {
     if (!options.table) throw new Error('table is required'); // Demand table be specified
@@ -396,10 +396,10 @@ function Dyno(options) {
   return _({
     config: config,
     defaultTable: options.tableName,
-    client: client,
-    docClient: docClient,
-    tableFreeClient: tableFreeClient,
-    tableFreeDocClient: tableFreeDocClient,
+    _client: client,
+    _docClient: docClient,
+    _tableFreeClient: tableFreeClient,
+    _tableFreeDocClient: tableFreeDocClient,
   }).extend(nativeFunctions, dynoExtensions);
 }
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ module.exports = Dyno;
  * @param {object} [options.logger] - a writable stream for detailed logging from the aws-sdk. See [constructor docs for details](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property).
  * @param {number} [options.maxRetries] - number of times to retry on retryable errors. See [constructor docs for details](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property).
  * @param {function} [options.costLogger] - a function that will be called with consumedCapacity
+ * @param {Dyno} [dynoInstance] - a Dyno instance that will share the underlying AWS client with the this one
  * @returns {client} a dyno client
  * @example
  * var Dyno = require('dyno');

--- a/index.js
+++ b/index.js
@@ -74,8 +74,8 @@ function Dyno(options) {
     logger: options.logger,
     maxRetries: options.maxRetries
   };
-  var client = util.wrapClient(new AWS.DynamoDB(config), options.costLogger);
-  var docClient = util.wrapDocClient(new AWS.DynamoDB.DocumentClient({ service: new AWS.DynamoDB(config) }), options.costLogger);
+  var client = new AWS.DynamoDB(config);
+  var docClient = util.wrapDocClient(new AWS.DynamoDB.DocumentClient({ service: client }), options.costLogger);
   var tableFreeClient = new AWS.DynamoDB(_(config).omit('params')); // no TableName in batch requests
   var tableFreeDocClient = util.wrapDocClient(new AWS.DynamoDB.DocumentClient({ service: tableFreeClient }), options.costLogger);
 
@@ -90,7 +90,7 @@ function Dyno(options) {
      * @param {function} [callback] - a function to handle the response. See [DynamoDB.listTables](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#listTables-property) for details.
      * @returns {Request}
      */
-    listTables: client.listTables,
+    listTables: client.listTables.bind(client),
     /**
      * Get table information. Passthrough to [DynamoDB.describeTable](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#describTable-property).
      *
@@ -100,7 +100,7 @@ function Dyno(options) {
      * @param {function} [callback] - a function to handle the response. See [DynamoDB.describeTable](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#describeTable-property) for details.
      * @returns {Request}
      */
-    describeTable: client.describeTable,
+    describeTable: client.describeTable.bind(client),
     /**
      * Perform a batch of get operations. Passthrough to [DocumentClient.batchGet](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#batchGet-property).
      *

--- a/index.js
+++ b/index.js
@@ -69,6 +69,9 @@ function Dyno(options, dynoInstance) {
 
   // Reuse DynamoDB Client
   if (dynoInstance && dynoInstance.client) {
+    if (Object.keys(options).length !== 1 || Object.keys(options)[0] !== 'costLogger') {
+      throw new Error('costLogger should be only option when AWS client is reused');
+    }
     client = dynoInstance.client;
     docClient = dynoInstance.docClient;
     tableFreeClient = dynoInstance.tableFreeClient;

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -6,12 +6,11 @@ var reduceCapacity = require('./util').reduceCapacity;
 module.exports = function(client, tableName) {
   var stream = {};
 
-  function readableStream(request, params, options) {
+  function readableStream(requestType, params, options) {
     options = options || {};
     var pages = options.pages || Infinity;
-
     var readable = new Readable(_({ objectMode: true }).defaults(options));
-    var nextRequest = client[request](params);
+    var nextRequest = client[requestType](params);
     var pending = false;
     var items = [];
 
@@ -37,7 +36,14 @@ module.exports = function(client, tableName) {
           }
 
           pages--;
-          nextRequest = pages && response.hasNextPage() ? response.nextPage() : false;
+          
+          nextRequest = pages && response.hasNextPage()
+            ? client[requestType](
+              Object.assign({}, params, {
+                ExclusiveStartKey: readable.LastEvaluatedKey,
+              })
+            )
+            : false;
 
           response.data.Items.forEach(function(item) { items.push(item); });
           readable._read();

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,14 +58,27 @@ function reduceCapacity(existing, incoming) {
   }
 }
 
+/**
+ * Cast CapacityUnits to ReadCapacityUnits or WriteCapacityUnits based on the cast type
+ * @param {Object} indexes  GlobalSecondaryIndexes or LocalSecondaryIndexes see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ConsumedCapacity.html#DDB-Type-ConsumedCapacity-GlobalSecondaryIndexes
+ * @param {string} castKey ReadCapacityUnits | WriteCapacityUnits
+ * 
+ */
 function castIndexesCapacity (indexes, castKey) {
   if (!indexes) return null;
-  return Object.fromEntries(indexes.keys.map(function(key) {
-    return [key, {[castKey]: indexes[key].castKey || indexes[key].CapacityUnits}];
+  return Object.fromEntries(Object.keys(indexes).map(function(key) {
+    return [key, {[castKey]: indexes[key][castKey] || indexes[key].CapacityUnits}];
   }));
 }
 
+/**
+ * Call the costLogger function configured in the options with consumed CapacityUnits 
+ * @param {object} res The response of dynamoDB request
+ * @param {string} type Read | Write
+ * @param {function} costLogger configured in the options
+ */
 function callCostLogger (res, type, costLogger) {
+  if (!costLogger) return;
   if (res && res.ConsumedCapacity) {
     let ConsumedCapacity = {};
     reduceCapacity(ConsumedCapacity, res.ConsumedCapacity);
@@ -151,5 +164,6 @@ function wrapDocClient (client, costLogger) {
 module.exports = {
   reduceCapacity,
   requestHandler,
-  wrapDocClient
+  wrapDocClient,
+  castIndexesCapacity
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,4 +58,73 @@ function reduceCapacity(existing, incoming) {
   }
 }
 
-module.exports.reduceCapacity = reduceCapacity;
+function requestHandler(costLogger, nativeMethod, type) {
+  if (!costLogger) {
+    return nativeMethod;
+  }
+  if (!['Write', 'Read'].includes(type)) {
+    throw new Error('Invalid capacity type');
+  }
+  return function(params, callback) {
+    params.ReturnConsumedCapacity = 'INDEXES';
+    nativeMethod(params, function (err, res) {
+      callback(err, res);
+      if (res && res.ConsumedCapacity) {
+        costLogger({
+          [`${type}ConsumedCapacity`]: res.ConsumedCapacity
+        });
+      }
+    });
+  };
+}
+
+/**
+ * Get if a method is a write or read method
+ * @param {string} fnName 
+ * @returns Write|Read
+ */
+function getMethodType (fnName) {
+  return [
+    'deleteTable',
+    'batchWriteItem',
+    'deleteItem',
+    'createTable',
+    'put',
+    'delete',
+    'update',
+    'batchWrite'
+  ].includes(fnName) ? 'Write' : 'Read';
+}
+
+function wrapClient (client, costLogger) {
+  return {
+    listTables: requestHandler(costLogger, client.listTables.bind(client), getMethodType('listTables')),
+    describeTable: requestHandler(costLogger, client.describeTable.bind(client), getMethodType('describeTable')),
+    createTable: requestHandler(costLogger, client.createTable.bind(client), getMethodType('createTable')),
+    deleteTable: requestHandler(costLogger, client.deleteTable.bind(client), getMethodType('deleteTable')),
+    batchGetItem: requestHandler(costLogger, client.batchGetItem.bind(client), getMethodType('batchGetItem')),
+    batchWriteItem: requestHandler(costLogger, client.batchWriteItem.bind(client), getMethodType('batchWriteItem')),
+    deleteItem: requestHandler(costLogger, client.deleteItem.bind(client), getMethodType('deleteItem')),
+    getItem: requestHandler(costLogger, client.getItem.bind(client), getMethodType('getItem')),
+  };
+}
+
+function wrapDocClient (client, costLogger) {
+  return {
+    batchGet: requestHandler(costLogger, client.batchGet.bind(client), getMethodType('batchGet')),
+    batchWrite: requestHandler(costLogger, client.batchWrite.bind(client), getMethodType('batchWrite')),
+    put: requestHandler(costLogger, client.put.bind(client), getMethodType('put')),
+    get: requestHandler(costLogger, client.get.bind(client), getMethodType('get')),
+    update: requestHandler(costLogger, client.update.bind(client), getMethodType('update')),
+    delete: requestHandler(costLogger, client.delete.bind(client), getMethodType('delete')),
+    query: requestHandler(costLogger, client.query.bind(client), getMethodType('query')),
+    scan: requestHandler(costLogger, client.scan.bind(client), getMethodType('scan'))
+  };
+}
+
+module.exports = {
+  reduceCapacity,
+  requestHandler,
+  wrapClient,
+  wrapDocClient
+};

--- a/lib/util.js
+++ b/lib/util.js
@@ -89,16 +89,10 @@ function requestHandler(costLogger, nativeMethod, type) {
   }
   return function(params, callback) {
     params.ReturnConsumedCapacity = 'INDEXES';
-    if (callback) {
-      nativeMethod(params, function (err, res) {
-        callCostLogger(res, type, costLogger);
-        callback(err, res);
-      });
-    } else {
-      nativeMethod(params).on('success', function (res) {
-        callCostLogger(res, type, costLogger);
-      });
-    }
+    return nativeMethod(params, function (err, res) {
+      callCostLogger(res, type, costLogger);
+      callback && callback(err, res);
+    });
   };
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -113,7 +113,7 @@ function requestHandler(costLogger, nativeMethod, type) {
   }
   return function(params, callback) {
     params.ReturnConsumedCapacity = 'INDEXES';
-    let start = Date.now();
+    const start = Date.now();
     if (callback) {
       return nativeMethod(params, function (err, res) {
         const Time = Date.now() - start;
@@ -123,12 +123,12 @@ function requestHandler(costLogger, nativeMethod, type) {
     }
     const request =  nativeMethod(params);
     const send = request.send.bind(request);
-    request.send = (callback2) => {
-      start = Date.now();
+    request.send = (callbackOfSend) => {
+      const sendStart = Date.now();
       send((err, res) => {
-        const Time = Date.now() - start;
+        const Time = Date.now() - sendStart;
         callCostLogger(res, type, costLogger, Time);
-        callback2 && callback2(err, res);
+        callbackOfSend && callbackOfSend(err, res);
       });
     };
     return request;

--- a/lib/util.js
+++ b/lib/util.js
@@ -86,11 +86,12 @@ function callCostLogger (res, type, costLogger, Time) {
     const castKey = `${type}CapacityUnits`;
     costLogger({
       ConsumedCapacity: {
+        CapacityUnits: ConsumedCapacity.CapacityUnits,
         [castKey]: ConsumedCapacity[castKey] || ConsumedCapacity.CapacityUnits || 0,
         GlobalSecondaryIndexes: castIndexesCapacity(ConsumedCapacity.GlobalSecondaryIndexes, castKey),
         LocalSecondaryIndexes: castIndexesCapacity(ConsumedCapacity.LocalSecondaryIndexes, castKey),
-        Time
-      }
+      },
+      Time
     });
   }
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,6 +58,13 @@ function reduceCapacity(existing, incoming) {
   }
 }
 
+function castIndexesCapacity (indexes, castKey) {
+  if (!indexes) return null;
+  return Object.fromEntries(indexes.keys.map(function(key) {
+    return [key, {[castKey]: indexes[key].castKey || indexes[key].CapacityUnits}];
+  }));
+}
+
 function callCostLogger (res, type, costLogger) {
   if (res && res.ConsumedCapacity) {
     let ConsumedCapacity = {};
@@ -65,7 +72,9 @@ function callCostLogger (res, type, costLogger) {
     const castKey = `${type}CapacityUnits`;
     costLogger({
       ConsumedCapacity: {
-        [castKey]: ConsumedCapacity[castKey] || ConsumedCapacity.CapacityUnits || 0
+        [castKey]: ConsumedCapacity[castKey] || ConsumedCapacity.CapacityUnits || 0,
+        GlobalSecondaryIndexes: castIndexesCapacity(ConsumedCapacity.GlobalSecondaryIndexes, castKey),
+        LocalSecondaryIndexes: castIndexesCapacity(ConsumedCapacity.LocalSecondaryIndexes, castKey)
       }
     });
   }
@@ -89,10 +98,21 @@ function requestHandler(costLogger, nativeMethod, type) {
   }
   return function(params, callback) {
     params.ReturnConsumedCapacity = 'INDEXES';
-    return nativeMethod(params, function (err, res) {
-      callCostLogger(res, type, costLogger);
-      callback && callback(err, res);
-    });
+    if (callback) {
+      return nativeMethod(params, function (err, res) {
+        callCostLogger(res, type, costLogger);
+        callback && callback(err, res);
+      });
+    }
+    const request =  nativeMethod(params);
+    const send = request.send.bind(request);
+    request.send = (callback2) => {
+      send((err, res) => {
+        callCostLogger(res, type, costLogger);
+        callback2 && callback2(err, res);
+      });
+    };
+    return request;
   };
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,6 +58,19 @@ function reduceCapacity(existing, incoming) {
   }
 }
 
+function callCostLogger (res, type, costLogger) {
+  if (res && res.ConsumedCapacity) {
+    let ConsumedCapacity = {};
+    reduceCapacity(ConsumedCapacity, res.ConsumedCapacity);
+    const castKey = `${type}CapacityUnits`;
+    costLogger({
+      ConsumedCapacity: {
+        [castKey]: ConsumedCapacity[castKey] || ConsumedCapacity.CapacityUnits || 0
+      }
+    });
+  }
+}
+
 /**
  * Wrap the native method of DynamoDB to call the costLogger in the callback.
  * If no costLogger is provided, just return the native method directly
@@ -76,14 +89,16 @@ function requestHandler(costLogger, nativeMethod, type) {
   }
   return function(params, callback) {
     params.ReturnConsumedCapacity = 'INDEXES';
-    nativeMethod(params, function (err, res) {
-      callback(err, res);
-      if (res && res.ConsumedCapacity) {
-        costLogger({
-          [`${type}ConsumedCapacity`]: res.ConsumedCapacity
-        });
-      }
-    });
+    if (callback) {
+      nativeMethod(params, function (err, res) {
+        callCostLogger(res, type, costLogger);
+        callback(err, res);
+      });
+    } else {
+      nativeMethod(params).on('success', function (res) {
+        callCostLogger(res, type, costLogger);
+      });
+    }
   };
 }
 
@@ -94,34 +109,11 @@ function requestHandler(costLogger, nativeMethod, type) {
  */
 function getMethodType (fnName) {
   return [
-    'deleteTable',
-    'batchWriteItem',
-    'deleteItem',
-    'createTable',
-    'put',
+    'batchWrite',
     'delete',
+    'put',
     'update',
-    'batchWrite'
   ].includes(fnName) ? 'Write' : 'Read';
-}
-
-
-/**
- * Wrap all methods used of DynamoDB Client with requestHandler
- * @param {object} client DynamoDB Client
- * @param {function} costLogger The function that will be called with casted consumedCapacity
- */
-function wrapClient (client, costLogger) {
-  return {
-    listTables: requestHandler(costLogger, client.listTables.bind(client), getMethodType('listTables')),
-    describeTable: requestHandler(costLogger, client.describeTable.bind(client), getMethodType('describeTable')),
-    createTable: requestHandler(costLogger, client.createTable.bind(client), getMethodType('createTable')),
-    deleteTable: requestHandler(costLogger, client.deleteTable.bind(client), getMethodType('deleteTable')),
-    batchGetItem: requestHandler(costLogger, client.batchGetItem.bind(client), getMethodType('batchGetItem')),
-    batchWriteItem: requestHandler(costLogger, client.batchWriteItem.bind(client), getMethodType('batchWriteItem')),
-    deleteItem: requestHandler(costLogger, client.deleteItem.bind(client), getMethodType('deleteItem')),
-    getItem: requestHandler(costLogger, client.getItem.bind(client), getMethodType('getItem')),
-  };
 }
 
 /**
@@ -131,21 +123,19 @@ function wrapClient (client, costLogger) {
  * @returns 
  */
 function wrapDocClient (client, costLogger) {
-  return {
-    batchGet: requestHandler(costLogger, client.batchGet.bind(client), getMethodType('batchGet')),
-    batchWrite: requestHandler(costLogger, client.batchWrite.bind(client), getMethodType('batchWrite')),
-    put: requestHandler(costLogger, client.put.bind(client), getMethodType('put')),
-    get: requestHandler(costLogger, client.get.bind(client), getMethodType('get')),
-    update: requestHandler(costLogger, client.update.bind(client), getMethodType('update')),
-    delete: requestHandler(costLogger, client.delete.bind(client), getMethodType('delete')),
-    query: requestHandler(costLogger, client.query.bind(client), getMethodType('query')),
-    scan: requestHandler(costLogger, client.scan.bind(client), getMethodType('scan'))
-  };
+  const methods = ['batchGet', 'batchWrite', 'put', 'get', 'update', 'delete', 'query', 'scan'];
+  return Object.fromEntries(
+    methods.map(function (m) {
+      return [
+        m,
+        requestHandler(costLogger, client[m].bind(client), getMethodType(m)),
+      ];
+    })
+  );
 }
 
 module.exports = {
   reduceCapacity,
   requestHandler,
-  wrapClient,
   wrapDocClient
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -76,8 +76,9 @@ function castIndexesCapacity (indexes, castKey) {
  * @param {object} res The response of dynamoDB request
  * @param {string} type Read | Write
  * @param {function} costLogger configured in the options
+ * @param {number} Time the time consumed
  */
-function callCostLogger (res, type, costLogger) {
+function callCostLogger (res, type, costLogger, Time) {
   if (!costLogger) return;
   if (res && res.ConsumedCapacity) {
     let ConsumedCapacity = {};
@@ -87,7 +88,8 @@ function callCostLogger (res, type, costLogger) {
       ConsumedCapacity: {
         [castKey]: ConsumedCapacity[castKey] || ConsumedCapacity.CapacityUnits || 0,
         GlobalSecondaryIndexes: castIndexesCapacity(ConsumedCapacity.GlobalSecondaryIndexes, castKey),
-        LocalSecondaryIndexes: castIndexesCapacity(ConsumedCapacity.LocalSecondaryIndexes, castKey)
+        LocalSecondaryIndexes: castIndexesCapacity(ConsumedCapacity.LocalSecondaryIndexes, castKey),
+        Time
       }
     });
   }
@@ -111,17 +113,21 @@ function requestHandler(costLogger, nativeMethod, type) {
   }
   return function(params, callback) {
     params.ReturnConsumedCapacity = 'INDEXES';
+    let start = Date.now();
     if (callback) {
       return nativeMethod(params, function (err, res) {
-        callCostLogger(res, type, costLogger);
+        const Time = Date.now() - start;
+        callCostLogger(res, type, costLogger, Time);
         callback && callback(err, res);
       });
     }
     const request =  nativeMethod(params);
     const send = request.send.bind(request);
     request.send = (callback2) => {
+      start = Date.now();
       send((err, res) => {
-        callCostLogger(res, type, costLogger);
+        const Time = Date.now() - start;
+        callCostLogger(res, type, costLogger, Time);
         callback2 && callback2(err, res);
       });
     };

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,6 +58,15 @@ function reduceCapacity(existing, incoming) {
   }
 }
 
+/**
+ * Wrap the native method of DynamoDB to call the costLogger in the callback.
+ * If no costLogger is provided, just return the native method directly
+ * 
+ * @param {function} costLogger The function that will be called with casted consumedCapacity
+ * @param {function} nativeMethod The native method of dynamoDB
+ * @param {string} type Indicate the method consumes Read or Write capacity
+ */
+
 function requestHandler(costLogger, nativeMethod, type) {
   if (!costLogger) {
     return nativeMethod;
@@ -96,6 +105,12 @@ function getMethodType (fnName) {
   ].includes(fnName) ? 'Write' : 'Read';
 }
 
+
+/**
+ * Wrap all methods used of DynamoDB Client with requestHandler
+ * @param {object} client DynamoDB Client
+ * @param {function} costLogger The function that will be called with casted consumedCapacity
+ */
 function wrapClient (client, costLogger) {
   return {
     listTables: requestHandler(costLogger, client.listTables.bind(client), getMethodType('listTables')),
@@ -109,6 +124,12 @@ function wrapClient (client, costLogger) {
   };
 }
 
+/**
+ * Wrap all methods used of DynamoDB DocumentClient with requestHandler
+ * @param {object} client DynamoDB DocumentClient
+ * @param {function} costLogger The function that will be called with casted consumedCapacity
+ * @returns 
+ */
 function wrapDocClient (client, costLogger) {
   return {
     batchGet: requestHandler(costLogger, client.batchGet.bind(client), getMethodType('batchGet')),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.6.0-alpha",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -519,6 +519,41 @@
         }
       }
     },
+    "@sinonjs/commons": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
+      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
+      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "dev": true
+    },
     "@types/estree": {
       "version": "0.0.48",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.48.tgz",
@@ -4506,6 +4541,12 @@
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -4800,6 +4841,12 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
       "dev": true
     },
     "lodash.ismatch": {
@@ -5594,6 +5641,19 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "nise": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
+      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
+    },
     "node-gyp-build": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
@@ -6014,6 +6074,23 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "3.0.0",
@@ -6708,6 +6785,28 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
+      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0",
+        "@sinonjs/fake-timers": "10.0.2",
+        "@sinonjs/samsam": "^7.0.1",
+        "diff": "^5.0.0",
+        "nise": "^5.1.2",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+          "dev": true
+        }
+      }
     },
     "slice-ansi": {
       "version": "4.0.0",
@@ -7661,6 +7760,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
       "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-fest": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.6.0",
+  "version": "1.6.0-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Simple DynamoDB client",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "documentation": "^13.2.5",
     "eslint": "^7.32.0",
     "nyc": "^15.1.0",
+    "sinon": "^15.0.1",
     "tape": "^4.2.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.6.0",
+  "version": "1.6.0-alpha",
   "description": "Simple DynamoDB client",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "pretest": "eslint bin lib test index.js",
-    "test": "nyc tape test/util.test.js",
+    "test": "nyc tape test/*.test.js",
     "docs": "documentation build index.js -f md > API.md",
     "coverage": "nyc report --reporter html && open coverage/index.html"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "pretest": "eslint bin lib test index.js",
-    "test": "nyc tape test/*.test.js",
+    "test": "nyc tape test/util.test.js",
     "docs": "documentation build index.js -f md > API.md",
     "coverage": "nyc report --reporter html && open coverage/index.html"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.6.0-alpha",
+  "version": "1.6.0",
   "description": "Simple DynamoDB client",
   "main": "index.js",
   "engines": {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -120,6 +120,7 @@ test('[cli] no table specified', function(assert) {
 dynamodb.test('[cli] list tables', function(assert) {
   runCli(['tables', 'local'], function(err, stdout) {
     assert.ifError(err, 'cli success');
+    console.log(err);
     assert.ok((new RegExp(dynamodb.tableName)).test(stdout), 'printed table name');
     assert.end();
   });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -120,7 +120,6 @@ test('[cli] no table specified', function(assert) {
 dynamodb.test('[cli] list tables', function(assert) {
   runCli(['tables', 'local'], function(err, stdout) {
     assert.ifError(err, 'cli success');
-    console.log(err);
     assert.ok((new RegExp(dynamodb.tableName)).test(stdout), 'printed table name');
     assert.end();
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -189,7 +189,7 @@ test('[index] reuse client', function(assert) {
 
   const dyno = Dyno(options);
   const dyno2 = Dyno({costLogger: costLogger2, dynoInstance: dyno});
-  assert.equal(dyno.client, dyno2.client, 'client is reused');
+  assert.equal(dyno._client, dyno2._client, 'client is reused');
   assert.equal(dyno.config, dyno2.config, 'config is reused');
   assert.end();
 });
@@ -219,7 +219,7 @@ test('[index] reuse client in multi method', function(assert) {
   );
   assert.equal(multiDyno.config.read, multiDyno2.config.read, 'read config is reused');
   assert.equal(multiDyno.config.write, multiDyno2.config.write, 'write config is reused');
-  assert.equal(multiDyno.read.client, multiDyno2.read.client, 'read client is reused');
+  assert.equal(multiDyno.read._client, multiDyno2.read._client, 'read client is reused');
   assert.equal(multiDyno.write.client, multiDyno2.write.client, 'write client is reused');
   assert.end();
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -194,6 +194,20 @@ test('[index] reuse client', function(assert) {
   assert.end();
 });
 
+test('[index] costLogger should be only option', function(assert) {
+  const options = {
+    table: 'my-table',
+    region: 'us-east-1',
+    endpoint: 'http://localhost:4567'
+  };
+
+  const dyno = Dyno(options);
+  assert.throws(function() {
+    Dyno({table: 'my-table'}, dyno);
+  }, /costLogger should be only option when AWS client is reused/, 'rejects option other than costLogger');
+  assert.end();
+});
+
 dynamodb.start();
 dynamodb.test('different costLoggers are called', function(assert) {
   const costLogger1 = sinon.stub();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,7 +15,6 @@ test('[index] invalid config', function(assert) {
 
 test('[index] expected properties', function(assert) {
   var dyno = Dyno({ table: 'my-table', region: 'us-east-1' });
-
   assert.equal(typeof dyno.config, 'object', 'exposes config object');
   assert.equal(typeof dyno.listTables, 'function', 'exposes listTables function');
   assert.equal(typeof dyno.describeTable, 'function', 'exposes describeTable function');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,6 +15,7 @@ test('[index] invalid config', function(assert) {
 
 test('[index] expected properties', function(assert) {
   var dyno = Dyno({ table: 'my-table', region: 'us-east-1' });
+
   assert.equal(typeof dyno.config, 'object', 'exposes config object');
   assert.equal(typeof dyno.listTables, 'function', 'exposes listTables function');
   assert.equal(typeof dyno.describeTable, 'function', 'exposes describeTable function');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -170,3 +170,24 @@ test('[index] configuration', function(assert) {
 
   assert.end();
 });
+
+test('[index] reuse client', function(assert) {
+  var config = {
+    table: 'my-table',
+    region: 'us-east-1',
+    endpoint: 'http://localhost:4567',
+    httpOptions: { timeout: 1000 },
+    accessKeyId: 'access',
+    secretAccessKey: 'secret',
+    sessionToken: 'session',
+    logger: console,
+    maxRetries: 10,
+    extra: 'crap'
+  };
+
+  var dyno = Dyno(config);
+  var dyno2 = Dyno(config, dyno);
+  assert.equal(dyno.client, dyno2.client, 'client is reused');
+  assert.equal(dyno.config, dyno2.config, 'config is reused');
+  assert.end();
+});

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,17 +1,16 @@
-/* eslint-disable no-unused-vars */
 /* eslint-env es6 */
 const test = require('tape');
-var _ = require('underscore');
-var crypto = require('crypto');
+const _ = require('underscore');
+const crypto = require('crypto');
 
 const reduceCapacity = require('../lib/util').reduceCapacity;
 const requestHandler = require('../lib/util').requestHandler;
 const castIndexesCapacity = require('../lib/util').castIndexesCapacity;
 const sinon = require('sinon');
-var Dyno = require('..');
-var testTables = require('./test-tables');
-var dynamodb = require('@mapbox/dynamodb-test')(test, 'dyno', testTables.idhash);
-var fixtures = _.range(500).map(function(i) {
+const Dyno = require('..');
+const testTables = require('./test-tables');
+const dynamodb = require('@mapbox/dynamodb-test')(test, 'dyno', testTables.idhash);
+const fixtures = _.range(500).map(function(i) {
   return {
     id: i.toString(),
     range: i,
@@ -202,13 +201,13 @@ dynamodb.start();
 dynamodb.test('[costLogger] client batchGet', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
   const timeStub = sinon.stub(Date, 'now').returns(10000);
-  var dyno = Dyno({
+  const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
     endpoint: 'http://localhost:4567',
     costLogger: costLoggerStub
   });
-  var params = { RequestItems: {} };
+  const params = { RequestItems: {} };
   params.RequestItems[dynamodb.tableName] = {
     Keys: _.range(10).map(function(i) {
       return { id: i.toString() };
@@ -227,14 +226,14 @@ dynamodb.test('[costLogger] client batchGet', fixtures, function(assert) {
 dynamodb.test('[costLogger] batchWrite', function(assert) {
   const costLoggerStub = sinon.stub();
   const timeStub = sinon.stub(Date, 'now').returns(10000);
-  var dyno = Dyno({
+  const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
     endpoint: 'http://localhost:4567',
     costLogger: costLoggerStub
   });
-  var records = randomItems(10);
-  var params = { RequestItems: {} };
+  const records = randomItems(10);
+  const params = { RequestItems: {} };
   params.RequestItems[dynamodb.tableName] = records.map(function(item) {
     return {
       PutRequest: { Item: item }
@@ -253,7 +252,7 @@ dynamodb.test('[costLogger] batchWrite', function(assert) {
 dynamodb.test('[costLogger] get', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
   const timeStub = sinon.stub(Date, 'now').returns(10000);
-  var dyno = Dyno({
+  const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
     endpoint: 'http://localhost:4567',
@@ -276,7 +275,7 @@ dynamodb.test('[costLogger] get', fixtures, function(assert) {
 dynamodb.test('[costLogger] delete', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
   const timeStub = sinon.stub(Date, 'now').returns(10000);
-  var dyno = Dyno({
+  const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
     endpoint: 'http://localhost:4567',
@@ -299,7 +298,7 @@ dynamodb.test('[costLogger] delete', fixtures, function(assert) {
 dynamodb.test('[costLogger] put', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
   const timeStub = sinon.stub(Date, 'now').returns(10000);
-  var dyno = Dyno({
+  const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
     endpoint: 'http://localhost:4567',
@@ -322,7 +321,7 @@ dynamodb.test('[costLogger] put', fixtures, function(assert) {
 dynamodb.test('[costLogger] update', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
   const timeStub = sinon.stub(Date, 'now').returns(10000);
-  var dyno = Dyno({
+  const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
     endpoint: 'http://localhost:4567',
@@ -347,7 +346,7 @@ dynamodb.test('[costLogger] update', fixtures, function(assert) {
 dynamodb.test('[costLogger] scan 1 page', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
   const timeStub = sinon.stub(Date, 'now').returns(10000);
-  var dyno = Dyno({
+  const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
     endpoint: 'http://localhost:4567',
@@ -371,7 +370,7 @@ dynamodb.test('[costLogger] scan 1 page', fixtures, function(assert) {
 dynamodb.test('[costLogger] query 1 page', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
   const timeStub = sinon.stub(Date, 'now').returns(10000);
-  var dyno = Dyno({
+  const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
     endpoint: 'http://localhost:4567',
@@ -399,7 +398,7 @@ dynamodb.test('[costLogger] query 1 page', fixtures, function(assert) {
 dynamodb.test('[costLogger] scan', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
   const timeStub = sinon.stub(Date, 'now').returns(10000);
-  var dyno = Dyno({
+  const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
     endpoint: 'http://localhost:4567',

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -146,7 +146,7 @@ test ('[requestHandler] return correct Time - non Stream', function (assert) {
   const wrappedMethod = requestHandler(costLogger, nativeMethod, 'Write');
   wrappedMethod({}, function(){});
   timerStub.restore();
-  assert.equal(costLogger.getCall(0).args[0].ConsumedCapacity.Time, 100, 'Consumed Time is 100');
+  assert.equal(costLogger.getCall(0).args[0].Time, 100, 'Consumed Time is 100');
   assert.end();
 });
 
@@ -170,7 +170,7 @@ test ('[requestHandler] return correct Time - Stream', function (assert) {
   };
   const wrappedMethod = requestHandler(costLogger, nativeMethod, 'Write');
   wrappedMethod({}).send();
-  assert.equal(costLogger.getCall(0).args[0].ConsumedCapacity.Time, 200, 'Consumed Time is 200');
+  assert.equal(costLogger.getCall(0).args[0].Time, 200, 'Consumed Time is 200');
   assert.end();
   timerStub.restore();
   
@@ -200,7 +200,6 @@ dynamodb.start();
 
 dynamodb.test('[costLogger] client batchGet', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
-  const timeStub = sinon.stub(Date, 'now').returns(10000);
   const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -215,17 +214,22 @@ dynamodb.test('[costLogger] client batchGet', fixtures, function(assert) {
   };
   dyno.batchGetItem(params, function(err) {
     assert.notOk(err, 'no error');
-    assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { ReadCapacityUnits: 10, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
-    }), 'costLoggerStub is called');
+    assert.deepEqual(
+      costLoggerStub.getCall(0).args[0].ConsumedCapacity,
+      {
+        CapacityUnits: 10,
+        ReadCapacityUnits: 10,
+        GlobalSecondaryIndexes: null,
+        LocalSecondaryIndexes: null,
+      },
+      'costLoggerStub is called'
+    ); 
     assert.end();
-    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] batchWrite', function(assert) {
   const costLoggerStub = sinon.stub();
-  const timeStub = sinon.stub(Date, 'now').returns(10000);
   const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -241,17 +245,22 @@ dynamodb.test('[costLogger] batchWrite', function(assert) {
   });
   dyno.batchWriteItem(params, function(err) {
     assert.notOk(err, 'no error');
-    assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { WriteCapacityUnits: 10, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
-    }), 'costLoggerStub is called');
+    assert.deepEqual(
+      costLoggerStub.getCall(0).args[0].ConsumedCapacity,
+      {
+        CapacityUnits: 10,
+        WriteCapacityUnits: 10,
+        GlobalSecondaryIndexes: null,
+        LocalSecondaryIndexes: null,
+      },
+      'costLoggerStub is called'
+    ); 
     assert.end();
-    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] get', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
-  const timeStub = sinon.stub(Date, 'now').returns(10000);
   const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -264,17 +273,22 @@ dynamodb.test('[costLogger] get', fixtures, function(assert) {
   };
   dyno.getItem(params, function(err) {
     assert.notOk(err, 'no error');
-    assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { ReadCapacityUnits: 1, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
-    }), 'costLoggerStub is called');
+    assert.deepEqual(
+      costLoggerStub.getCall(0).args[0].ConsumedCapacity,
+      {
+        CapacityUnits: 1,
+        ReadCapacityUnits: 1,
+        GlobalSecondaryIndexes: null,
+        LocalSecondaryIndexes: null,
+      },
+      'costLoggerStub is called'
+    ); 
     assert.end();
-    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] delete', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
-  const timeStub = sinon.stub(Date, 'now').returns(10000);
   const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -287,17 +301,22 @@ dynamodb.test('[costLogger] delete', fixtures, function(assert) {
   };
   dyno.deleteItem(params, function(err) {
     assert.notOk(err, 'no error');
-    assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { WriteCapacityUnits: 6, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
-    }), 'costLoggerStub is called');
+    assert.deepEqual(
+      costLoggerStub.getCall(0).args[0].ConsumedCapacity,
+      {
+        CapacityUnits: 6,
+        WriteCapacityUnits: 6,
+        GlobalSecondaryIndexes: null,
+        LocalSecondaryIndexes: null,
+      },
+      'costLoggerStub is called'
+    ); 
     assert.end();
-    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] put', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
-  const timeStub = sinon.stub(Date, 'now').returns(10000);
   const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -310,17 +329,22 @@ dynamodb.test('[costLogger] put', fixtures, function(assert) {
   };
   dyno.putItem(params, function(err) {
     assert.notOk(err, 'no error');
-    assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { WriteCapacityUnits: 6, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
-    }), 'costLoggerStub is called');
+    assert.deepEqual(
+      costLoggerStub.getCall(0).args[0].ConsumedCapacity,
+      {
+        CapacityUnits: 6,
+        WriteCapacityUnits: 6,
+        GlobalSecondaryIndexes: null,
+        LocalSecondaryIndexes: null,
+      },
+      'costLoggerStub is called'
+    ); 
     assert.end();
-    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] update', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
-  const timeStub = sinon.stub(Date, 'now').returns(10000);
   const dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -335,11 +359,17 @@ dynamodb.test('[costLogger] update', fixtures, function(assert) {
   };
   dyno.updateItem(params, function(err) {
     assert.notOk(err, 'no error');
-    assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { WriteCapacityUnits: 6, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
-    }), 'costLoggerStub is called');
+    assert.deepEqual(
+      costLoggerStub.getCall(0).args[0].ConsumedCapacity,
+      {
+        CapacityUnits: 6,
+        WriteCapacityUnits: 6,
+        GlobalSecondaryIndexes: null,
+        LocalSecondaryIndexes: null,
+      },
+      'costLoggerStub is called'
+    ); 
     assert.end();
-    timeStub.restore();
   });
 });
 
@@ -358,8 +388,8 @@ dynamodb.test('[costLogger] scan 1 page', fixtures, function(assert) {
   };
   dyno.scan(params, function(err) {
     assert.notOk(err, 'no error');
-    assert.deepEqual(costLoggerStub.getCall(0).args[0], 
-      { ConsumedCapacity: { ReadCapacityUnits: 127.5, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0  } }, 
+    assert.deepEqual(costLoggerStub.getCall(0).args[0].ConsumedCapacity, 
+      { CapacityUnits: 127.5, ReadCapacityUnits: 127.5, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null }, 
       'costLoggerStub is called');
     assert.notOk(costLoggerStub.getCall(1), 'only called 1 time'); 
     assert.end();
@@ -386,8 +416,8 @@ dynamodb.test('[costLogger] query 1 page', fixtures, function(assert) {
   };
   dyno.query(params, function(err) {
     assert.notOk(err, 'no error');
-    assert.deepEqual(costLoggerStub.getCall(0).args[0], 
-      { ConsumedCapacity: { ReadCapacityUnits: 1, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0  } }, 
+    assert.deepEqual(costLoggerStub.getCall(0).args[0].ConsumedCapacity, 
+      { CapacityUnits: 1, ReadCapacityUnits: 1, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null }, 
       'costLoggerStub is called');
     assert.notOk(costLoggerStub.getCall(1), 'only called 1 time'); 
     assert.end();
@@ -410,8 +440,8 @@ dynamodb.test('[costLogger] scan', fixtures, function(assert) {
   };
   dyno.scan(scanParams, function(err) {
     assert.notOk(err, 'no scan error');
-    assert.deepEqual(costLoggerStub.getCall(1).args[0], { ConsumedCapacity: { ReadCapacityUnits: 127.5, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } }, 'costLoggerStub is called');
-    assert.deepEqual(costLoggerStub.getCall(2).args[0], { ConsumedCapacity: { ReadCapacityUnits: 59, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } }, 'costLoggerStub is called');
+    assert.deepEqual(costLoggerStub.getCall(1).args[0].ConsumedCapacity, { CapacityUnits: 127.5,ReadCapacityUnits: 127.5, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null }, 'costLoggerStub is called');
+    assert.deepEqual(costLoggerStub.getCall(2).args[0].ConsumedCapacity, { CapacityUnits: 59, ReadCapacityUnits: 59, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null }, 'costLoggerStub is called');
     assert.notOk(costLoggerStub.getCall(3), 'called 2 times');
     assert.end();
     timeStub.restore();

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,6 +1,10 @@
 /* eslint-env es6 */
 const test = require('tape');
 const reduceCapacity = require('../lib/util').reduceCapacity;
+const requestHandler = require('../lib/util').requestHandler;
+const wrapClient = require('../lib/util').wrapClient;
+const wrapDocClient = require('../lib/util').wrapDocClient;
+const sinon = require('sinon');
 
 test('[reduceCapacity] parses new data format correctly', function (assert) {
   const src = [{
@@ -63,5 +67,159 @@ test('[reduceCapacity] merges old data format correctly', function (assert) {
 
 test('[reduceCapacity] does not crash if dst is empty', function (assert) {
   reduceCapacity(null, []);
+  assert.end();
+});
+
+test('[requestHandler] returns original method if no costLogger', function (assert) {
+  const func = () => {};
+  assert.strictEqual(requestHandler(null, func), func);
+  assert.end();
+});
+
+test('[requestHandler] throws error if capacity type is incorrect', function (assert) {
+  assert.throws(() => {
+    requestHandler({}, () => {}, 'foo');
+  }, new Error('Invalid capacity type'));
+  assert.end();
+});
+
+test ('[requestHandler] ReturnConsumedCapacity param is set as INDEXES', function (assert) {
+  let newParams;
+  const nativeMethod = function (params, callback) {
+    newParams = params;
+    callback(null, {
+      ConsumedCapacity: 100
+    });
+  };
+  const wrappedMethod = requestHandler(function(){}, nativeMethod, 'Write');
+  wrappedMethod({}, function(){});
+  assert.equal(newParams.ReturnConsumedCapacity, 'INDEXES', 'ReturnConsumedCapacity is INDEXES');
+  assert.end();
+});
+
+test ('[requestHandler] costLogger is called with consumedCapacity', function (assert) {
+  const costLogger = sinon.stub();
+  const nativeMethod = function (params, callback) {
+    callback(null, {
+      ConsumedCapacity: 100
+    });
+  };
+  const wrappedMethod = requestHandler(costLogger, nativeMethod, 'Write');
+  wrappedMethod({}, function(){});
+  assert.ok(costLogger.calledOnceWith({ WriteConsumedCapacity: 100 }), 'Get correct consumedCapacity');
+  assert.end();
+});
+
+test ('[requestHandler] do not call costLogger if no consumedCapacity', function (assert) {
+  const costLogger = sinon.stub();
+  const nativeMethod = function (params, callback) {
+    callback(null, {
+      ConsumedCapacity: 0
+    });
+  };
+  const wrappedMethod = requestHandler(costLogger, nativeMethod, 'Write');
+  wrappedMethod({}, function(){});
+  assert.ok(costLogger.notCalled, 'costLogger is not called');
+  assert.end();
+});
+
+test('[wrapClient] return correct method', function (assert) {
+  const client = {
+    listTables: function(param, callback) { callback(null, {ConsumedCapacity: 100}); },
+    describeTable: function(param, callback) { callback(null, {ConsumedCapacity: 200}); },
+    createTable: function(param, callback) { callback(null, {ConsumedCapacity: 300}); },
+    deleteTable: function(param, callback) { callback(null, {ConsumedCapacity: 400}); },
+    batchGetItem: function(param, callback) { callback(null, {ConsumedCapacity: 500}); },
+    batchWriteItem: function(param, callback) { callback(null, {ConsumedCapacity: 600}); },
+    deleteItem: function(param, callback) { callback(null, {ConsumedCapacity: 700}); },
+    getItem: function(param, callback) { callback(null, {ConsumedCapacity: 800}); },
+  };
+  const costLoggerStub = sinon.stub();
+  const wrappedClient = wrapClient(client, costLoggerStub);
+  const callbackStub = sinon.stub();
+  
+  wrappedClient.listTables({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of listTables is called');
+  assert.ok(costLoggerStub.calledWith({ ReadConsumedCapacity: 100 }), 'costLoggerStub is called');
+
+  wrappedClient.describeTable({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of describeTable is called');
+  assert.ok(costLoggerStub.calledWith({ ReadConsumedCapacity: 200 }), 'costLoggerStub is called');
+
+  wrappedClient.createTable({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of createTable is called');
+  assert.ok(costLoggerStub.calledWith({ WriteConsumedCapacity: 300 }), 'costLoggerStub is called');
+  
+  wrappedClient.deleteTable({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of deleteTable is called');
+  assert.ok(costLoggerStub.calledWith({ WriteConsumedCapacity: 400 }), 'costLoggerStub is called');
+  
+  wrappedClient.batchGetItem({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of batchGetItem is called');
+  assert.ok(costLoggerStub.calledWith({ ReadConsumedCapacity: 500 }), 'costLoggerStub is called');
+  
+  wrappedClient.batchWriteItem({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of batchWriteItem is called');
+  assert.ok(costLoggerStub.calledWith({ WriteConsumedCapacity: 600 }), 'costLoggerStub is called');
+  
+  wrappedClient.deleteItem({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of deleteItem is called');
+  assert.ok(costLoggerStub.calledWith({ WriteConsumedCapacity: 700 }), 'costLoggerStub is called');
+
+  wrappedClient.getItem({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of getItem is called');
+  assert.ok(costLoggerStub.calledWith({ ReadConsumedCapacity: 800 }), 'costLoggerStub is called');
+
+  assert.end();
+});
+
+test('[wrapDocClient] return correct method', function (assert) {
+  const docClient = {
+    batchGet: function(param, callback) { callback(null, {ConsumedCapacity: 100}); },
+    batchWrite: function(param, callback) { callback(null, {ConsumedCapacity: 200}); },
+    get: function(param, callback) { callback(null, {ConsumedCapacity: 300}); },
+    update: function(param, callback) { callback(null, {ConsumedCapacity: 400}); },
+    put: function(param, callback) { callback(null, {ConsumedCapacity: 500}); },
+    delete: function(param, callback) { callback(null, {ConsumedCapacity: 600}); },
+    query: function(param, callback) { callback(null, {ConsumedCapacity: 700}); },
+    scan: function(param, callback) { callback(null, {ConsumedCapacity: 800}); },
+  };
+  const costLoggerStub = sinon.stub();
+  const wrappedClient = wrapDocClient(docClient, costLoggerStub);
+  const callbackStub = sinon.stub();
+  
+  wrappedClient.batchGet({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of batchGet is called');
+  assert.ok(costLoggerStub.calledWith({ ReadConsumedCapacity: 100 }), 'costLoggerStub is called');
+
+  wrappedClient.batchWrite({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of batchWrite is called');
+  assert.ok(costLoggerStub.calledWith({ WriteConsumedCapacity: 200 }), 'costLoggerStub is called');
+
+  wrappedClient.get({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of get is called');
+  assert.ok(costLoggerStub.calledWith({ ReadConsumedCapacity: 300 }), 'costLoggerStub is called');
+  
+  wrappedClient.update({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of update is called');
+  assert.ok(costLoggerStub.calledWith({ WriteConsumedCapacity: 400 }), 'costLoggerStub is called');
+
+  wrappedClient.put({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of put is called');
+  assert.ok(costLoggerStub.calledWith({ WriteConsumedCapacity: 500 }), 'costLoggerStub is called');
+  
+  wrappedClient.delete({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of delete is called');
+  assert.ok(costLoggerStub.calledWith({ WriteConsumedCapacity: 600 }), 'costLoggerStub is called');
+  
+  
+  wrappedClient.query({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of query is called');
+  assert.ok(costLoggerStub.calledWith({ ReadConsumedCapacity: 700 }), 'costLoggerStub is called');
+  
+  wrappedClient.scan({}, callbackStub);
+  assert.ok(callbackStub.called, 'callback of scan is called');
+  assert.ok(costLoggerStub.calledWith({ ReadConsumedCapacity: 800 }), 'costLoggerStub is called');
+
   assert.end();
 });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -266,7 +266,7 @@ dynamodb.test('[costLogger] scan', function(assert) {
   });
   const params = {
     TableName: dynamodb.tableName,
-    Page: 1
+    Pages: 1
   };
   dyno.putItem({
     TableName: dynamodb.tableName,
@@ -294,14 +294,13 @@ dynamodb.test('[costLogger] query', function(assert) {
     ExpressionAttributeNames: { '#id': 'id' },
     ExpressionAttributeValues: { ':id': item.id },
     KeyConditionExpression: '#id = :id',
-    // Pages: 1 
+    Pages: 1 
   };
   dyno.putItem({
     TableName: dynamodb.tableName,
     Item: item
   }, function() {
-    dyno.query(params, function(err, res) {
-      console.log(res);
+    dyno.query(params, function(err) {
       assert.notOk(err, 'no error');
       assert.deepEqual(costLoggerStub.getCall(1).args[0], { ConsumedCapacity: { ReadCapacityUnits: 0.5 } }, 'costLoggerStub is called');
       assert.end();

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -158,6 +158,7 @@ dynamodb.start();
 
 dynamodb.test('[costLogger] client batchGet', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
+  const timeStub = sinon.stub(Date, 'now').returns(10000);
   var dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -173,14 +174,16 @@ dynamodb.test('[costLogger] client batchGet', fixtures, function(assert) {
   dyno.batchGetItem(params, function(err) {
     assert.notOk(err, 'no error');
     assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { ReadCapacityUnits: 10, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null } 
+      ConsumedCapacity: { ReadCapacityUnits: 10, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
     }), 'costLoggerStub is called');
     assert.end();
+    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] batchWrite', function(assert) {
   const costLoggerStub = sinon.stub();
+  const timeStub = sinon.stub(Date, 'now').returns(10000);
   var dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -197,14 +200,16 @@ dynamodb.test('[costLogger] batchWrite', function(assert) {
   dyno.batchWriteItem(params, function(err) {
     assert.notOk(err, 'no error');
     assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { WriteCapacityUnits: 10, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null } 
+      ConsumedCapacity: { WriteCapacityUnits: 10, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
     }), 'costLoggerStub is called');
     assert.end();
+    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] get', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
+  const timeStub = sinon.stub(Date, 'now').returns(10000);
   var dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -218,14 +223,16 @@ dynamodb.test('[costLogger] get', fixtures, function(assert) {
   dyno.getItem(params, function(err) {
     assert.notOk(err, 'no error');
     assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { ReadCapacityUnits: 1, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null } 
+      ConsumedCapacity: { ReadCapacityUnits: 1, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
     }), 'costLoggerStub is called');
     assert.end();
+    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] delete', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
+  const timeStub = sinon.stub(Date, 'now').returns(10000);
   var dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -239,14 +246,16 @@ dynamodb.test('[costLogger] delete', fixtures, function(assert) {
   dyno.deleteItem(params, function(err) {
     assert.notOk(err, 'no error');
     assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { WriteCapacityUnits: 6, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null } 
+      ConsumedCapacity: { WriteCapacityUnits: 6, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
     }), 'costLoggerStub is called');
     assert.end();
+    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] put', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
+  const timeStub = sinon.stub(Date, 'now').returns(10000);
   var dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -260,14 +269,16 @@ dynamodb.test('[costLogger] put', fixtures, function(assert) {
   dyno.putItem(params, function(err) {
     assert.notOk(err, 'no error');
     assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { WriteCapacityUnits: 6, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null } 
+      ConsumedCapacity: { WriteCapacityUnits: 6, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
     }), 'costLoggerStub is called');
     assert.end();
+    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] update', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
+  const timeStub = sinon.stub(Date, 'now').returns(10000);
   var dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -283,14 +294,16 @@ dynamodb.test('[costLogger] update', fixtures, function(assert) {
   dyno.updateItem(params, function(err) {
     assert.notOk(err, 'no error');
     assert.ok(costLoggerStub.calledWith({ 
-      ConsumedCapacity: { WriteCapacityUnits: 6, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null } 
+      ConsumedCapacity: { WriteCapacityUnits: 6, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } 
     }), 'costLoggerStub is called');
     assert.end();
+    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] scan 1 page', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
+  const timeStub = sinon.stub(Date, 'now').returns(10000);
   var dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -304,15 +317,17 @@ dynamodb.test('[costLogger] scan 1 page', fixtures, function(assert) {
   dyno.scan(params, function(err) {
     assert.notOk(err, 'no error');
     assert.deepEqual(costLoggerStub.getCall(0).args[0], 
-      { ConsumedCapacity: { ReadCapacityUnits: 127.5, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null  } }, 
+      { ConsumedCapacity: { ReadCapacityUnits: 127.5, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0  } }, 
       'costLoggerStub is called');
     assert.notOk(costLoggerStub.getCall(1), 'only called 1 time'); 
     assert.end();
+    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] query 1 page', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
+  const timeStub = sinon.stub(Date, 'now').returns(10000);
   var dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -330,15 +345,17 @@ dynamodb.test('[costLogger] query 1 page', fixtures, function(assert) {
   dyno.query(params, function(err) {
     assert.notOk(err, 'no error');
     assert.deepEqual(costLoggerStub.getCall(0).args[0], 
-      { ConsumedCapacity: { ReadCapacityUnits: 1, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null  } }, 
+      { ConsumedCapacity: { ReadCapacityUnits: 1, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0  } }, 
       'costLoggerStub is called');
     assert.notOk(costLoggerStub.getCall(1), 'only called 1 time'); 
     assert.end();
+    timeStub.restore();
   });
 });
 
 dynamodb.test('[costLogger] scan', fixtures, function(assert) {
   const costLoggerStub = sinon.stub();
+  const timeStub = sinon.stub(Date, 'now').returns(10000);
   var dyno = Dyno({
     table: dynamodb.tableName,
     region: 'local',
@@ -351,10 +368,11 @@ dynamodb.test('[costLogger] scan', fixtures, function(assert) {
   };
   dyno.scan(scanParams, function(err) {
     assert.notOk(err, 'no scan error');
-    assert.deepEqual(costLoggerStub.getCall(1).args[0], { ConsumedCapacity: { ReadCapacityUnits: 127.5, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null } }, 'costLoggerStub is called');
-    assert.deepEqual(costLoggerStub.getCall(2).args[0], { ConsumedCapacity: { ReadCapacityUnits: 59, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null } }, 'costLoggerStub is called');
+    assert.deepEqual(costLoggerStub.getCall(1).args[0], { ConsumedCapacity: { ReadCapacityUnits: 127.5, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } }, 'costLoggerStub is called');
+    assert.deepEqual(costLoggerStub.getCall(2).args[0], { ConsumedCapacity: { ReadCapacityUnits: 59, GlobalSecondaryIndexes: null, LocalSecondaryIndexes: null, Time: 0 } }, 'costLoggerStub is called');
     assert.notOk(costLoggerStub.getCall(3), 'called 2 times');
     assert.end();
+    timeStub.restore();
   });
 });
 dynamodb.delete();


### PR DESCRIPTION
Added a new type of logger that logs structured capacity usage data (ReadCapacityUnits and WriteCapacityUnits) that we can easily use for all our services to get a clear picture of which requests from which service are responsible for our costs.

Detect if the `costLogger` is set in `options`, and if it is:
- Add `ReturnConsumedCapacity: INDEXES` parameter to all executed requests to DynamoDB
- On return from each request, extracted WriteCapacityUnits and ReadCapacityUnits from the response and call the logger function with them. 
- If there is a `dynoInstance` in the option, the `DynamoDBCLient` will be reused

Why don't we use the `logger` option of DynamoDBClient? It is bonded with the instance,  so it is impossible to use different logger for each endpoint while sharing the DynamoDBClient instance.