### PR TITLE
Add asynchronous versions of existing methods that support callbacks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,11 @@
     "semi": [2, "always"]
   },
   "env": {
-      "node": true
+      "node": true,
+      "es6": true
+  },
+  "parserOptions": {
+    "ecmaVersion": 8
   },
   "globals": {
       "process": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.6.1
+## v1.6.2
 - Add asynchronous versions of existing methods that support callbacks
 
 ## v1.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.6.1
+- Add asynchronous versions of existing methods that support callbacks
+
 ## v1.6.0
 
 - Support passing a `costLogger` which will be called with casted `ConsumedCapacity`

--- a/index.js
+++ b/index.js
@@ -393,17 +393,15 @@ function Dyno(options) {
     delete dynoExtensions.scanStream;
   }
   
-  Object.entries(nativeFunctions).forEach(function ([k, v]) {
-    if (typeof v === 'function') {
-      nativeFunctions[`${k}Async`] = promisify(v);
-    }
-  });
+  for (const name of Object.keys(nativeFunctions)) {
+    nativeFunctions[`${name}Async`] = promisify(nativeFunctions[name]);
+  }
 
-  ['createTable', 'deleteTable', 'query', 'scan'].forEach(function(method) {
-    if (typeof dynoExtensions[method] === 'function') {
-      dynoExtensions[`${method}Async`] = promisify(dynoExtensions[method]);
+  for(const name of ['createTable', 'deleteTable', 'query', 'scan']) {
+    if (dynoExtensions[name]) {
+      dynoExtensions[`${name}Async`] = promisify(dynoExtensions[name]);
     }
-  });
+  }
 
   // Glue everything together
   return _({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.6.1",
+  "version": "1.6.2-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dyno",
-      "version": "1.6.1",
+      "version": "1.6.2-alpha",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.6.2-alpha",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/dyno",
-      "version": "1.6.2-alpha",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.6.2-alpha",
+  "version": "1.6.2",
   "description": "Simple DynamoDB client",
   "main": "index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/dyno",
-  "version": "1.6.1",
+  "version": "1.6.2-alpha",
   "description": "Simple DynamoDB client",
   "main": "index.js",
   "engines": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -136,22 +136,48 @@ test('[index] expected properties', function(assert) {
   );
 
   assert.equal(typeof multi.config, 'object', 'multi-client exposes config object');
+
   assert.equal(typeof multi.listTables, 'function', 'multi-client exposes listTables function');
+  assert.equal(typeof multi.listTablesAsync, 'function', 'multi-client exposes listTablesAsync function');
+
   assert.equal(typeof multi.describeTable, 'function', 'multi-client exposes describeTable function');
+  assert.equal(typeof multi.describeTableAsync, 'function', 'multi-client exposes describeTableAsync function');
+
   assert.equal(typeof multi.batchGetItem, 'function', 'multi-client exposes batchGetItem function');
+  assert.equal(typeof multi.batchGetItemAsync, 'function', 'multi-client exposes batchGetItemAsync function');
+
   assert.equal(typeof multi.batchWriteItem, 'function', 'multi-client exposes batchWriteItem function');
+  assert.equal(typeof multi.batchWriteItemAsync, 'function', 'multi-client exposes batchWriteItemAsync function');
+
   assert.equal(typeof multi.deleteItem, 'function', 'multi-client exposes deleteItem function');
+  assert.equal(typeof multi.deleteItemAsync, 'function', 'multi-client exposes deleteItemAsync function');
+
   assert.equal(typeof multi.getItem, 'function', 'multi-client exposes getItem function');
+  assert.equal(typeof multi.getItemAsync, 'function', 'multi-client exposes getItemAsync function');
+
   assert.equal(typeof multi.putItem, 'function', 'multi-client exposes putItem function');
+  assert.equal(typeof multi.putItemAsync, 'function', 'multi-client exposes putItemAsync function');
+
   assert.equal(typeof multi.query, 'function', 'multi-client exposes query function');
+  assert.equal(typeof multi.queryAsync, 'function', 'multi-client exposes queryAsync function');
+
   assert.equal(typeof multi.scan, 'function', 'multi-client exposes scan function');
+  assert.equal(typeof multi.scanAsync, 'function', 'multi-client exposes scanAsync function');
+
   assert.equal(typeof multi.updateItem, 'function', 'multi-client exposes updateItem function');
+  assert.equal(typeof multi.updateItemAsync, 'function', 'multi-client exposes updateItemAsync function');
+
   assert.equal(typeof multi.batchGetItemRequests, 'function', 'exposes batchGetItemRequests function');
   assert.equal(typeof multi.batchWriteItemRequests, 'function', 'exposes batchWriteItemRequests function');
   assert.equal(typeof multi.batchGetAll, 'function', 'exposes batchGetAll function');
   assert.equal(typeof multi.batchWriteAll, 'function', 'exposes batchWriteAll function');
+
   assert.equal(typeof multi.createTable, 'function', 'multi-client exposes createTable function');
+  assert.equal(typeof multi.createTableAsync, 'function', 'multi-client exposes createTableAsync function');
+
   assert.equal(typeof multi.deleteTable, 'function', 'multi-client exposes deleteTable function');
+  assert.equal(typeof multi.deleteTableAsync, 'function', 'multi-client exposes deleteTableAsync function');
+
   assert.equal(typeof multi.queryStream, 'function', 'multi-client exposes queryStream function');
   assert.equal(typeof multi.scanStream, 'function', 'multi-client exposes scanStream function');
   assert.equal(typeof multi.putStream, 'function', 'multi-client exposes putStream function');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -47,44 +47,85 @@ test('[index] expected properties', function(assert) {
 
   assert.equal(typeof read.config, 'object', 'read-only client exposes config object');
   assert.equal(typeof read.listTables, 'function', 'read-only client exposes listTables function');
+  assert.equal(typeof read.listTablesAsync, 'function', 'read-only client exposes listTablesAsync function');
+
   assert.equal(typeof read.describeTable, 'function', 'read-only client exposes describeTable function');
+  assert.equal(typeof read.describeTableAsync, 'function', 'read-only client exposes describeTableAsync function');
+  
   assert.equal(typeof read.batchGetItem, 'function', 'read-only client exposes batchGetItem function');
+  assert.equal(typeof read.batchGetItemAsync, 'function', 'read-only client exposes batchGetItemAsync function');
+  
   assert.equal(typeof read.batchWriteItem, 'undefined', 'read-only client does not expose batchWriteItem function');
+  
   assert.equal(typeof read.deleteItem, 'undefined', 'read-only client does not expose deleteItem function');
+  
   assert.equal(typeof read.getItem, 'function', 'read-only client exposes getItem function');
+  assert.equal(typeof read.getItemAsync, 'function', 'read-only client exposes getItemAsync function');
+  
   assert.equal(typeof read.putItem, 'undefined', 'read-only client does not expose putItem function');
+  
   assert.equal(typeof read.query, 'function', 'read-only client exposes query function');
+  assert.equal(typeof read.queryAsync, 'function', 'read-only client exposes queryAsync function');
+  
   assert.equal(typeof read.scan, 'function', 'read-only client exposes scan function');
+  assert.equal(typeof read.scanAsync, 'function', 'read-only client exposes scanAsync function');
+  
   assert.equal(typeof read.updateItem, 'undefined', 'read-only client does not expose updateItem function');
+  
   assert.equal(typeof read.batchGetItemRequests, 'function', 'read-only client exposes batchGetItemRequests function');
   assert.equal(typeof read.batchWriteItemRequests, 'undefined', 'read-only client does not expose batchWriteItemRequests function');
   assert.equal(typeof read.batchGetAll, 'function', 'read-only client exposes batchGetAll function');
   assert.equal(typeof read.batchWriteAll, 'undefined', 'read-only client does not expose batchWriteAll function');
+  
   assert.equal(typeof read.createTable, 'function', 'read-only client exposes createTable function');
+  assert.equal(typeof read.createTableAsync, 'function', 'read-only client exposes createTableAsync function');
+  
   assert.equal(typeof read.deleteTable, 'function', 'read-only client exposes deleteTable function');
+  assert.equal(typeof read.deleteTableAsync, 'function', 'read-only client exposes deleteTableAsync function');
+  
   assert.equal(typeof read.queryStream, 'function', 'read-only client exposes queryStream function');
   assert.equal(typeof read.scanStream, 'function', 'read-only client exposes scanStream function');
   assert.equal(typeof read.putStream, 'undefined', 'read-only client does not expose putStream function');
+  
 
   var write = Dyno({ table: 'my-table', region: 'us-east-1', write: true });
 
   assert.equal(typeof write.config, 'object', 'write-only client exposes config object');
   assert.equal(typeof write.listTables, 'function', 'write-only client exposes listTables function');
+  assert.equal(typeof write.listTablesAsync, 'function', 'write-only client exposes listTablesAsync function');
+
   assert.equal(typeof write.describeTable, 'function', 'write-only client exposes describeTable function');
+  assert.equal(typeof write.describeTableAsync, 'function', 'write-only client exposes describeTableAsync function');
+
   assert.equal(typeof write.batchGetItem, 'undefined', 'write-only client does not expose batchGetItem function');
   assert.equal(typeof write.batchWriteItem, 'function', 'write-only client exposes batchWriteItem function');
+
   assert.equal(typeof write.deleteItem, 'function', 'write-only client exposes deleteItem function');
+  assert.equal(typeof write.deleteItemAsync, 'function', 'write-only client exposes deleteItemAsync function');
+
   assert.equal(typeof write.getItem, 'undefined', 'write-only client does not expose getItem function');
+
   assert.equal(typeof write.putItem, 'function', 'write-only client exposes putItem function');
+  assert.equal(typeof write.putItemAsync, 'function', 'write-only client exposes putItemAsync function');
+
   assert.equal(typeof write.query, 'undefined', 'write-only client does not expose query function');
   assert.equal(typeof write.scan, 'undefined', 'write-only client does not expose scan function');
+
   assert.equal(typeof write.updateItem, 'function', 'write-only client exposes updateItem function');
+  assert.equal(typeof write.updateItemAsync, 'function', 'write-only client exposes updateItemAsync function');
+
   assert.equal(typeof write.batchGetItemRequests, 'undefined', 'write-only client does not expose batchGetItemRequests function');
+
   assert.equal(typeof write.batchWriteItemRequests, 'function', 'write-only client exposes batchWriteItemRequests function');
   assert.equal(typeof write.batchGetAll, 'undefined', 'write-only client does not expose batchGetAll function');
   assert.equal(typeof write.batchWriteAll, 'function', 'write-only client exposes batchWriteAll function');
+
   assert.equal(typeof write.createTable, 'function', 'write-only client exposes createTable function');
+  assert.equal(typeof write.createTableAsync, 'function', 'write-only client exposes createTableAsync function');
+
   assert.equal(typeof write.deleteTable, 'function', 'write-only client exposes deleteTable function');
+  assert.equal(typeof write.deleteTableAsync, 'function', 'write-only client exposes deleteTableAsync function');
+
   assert.equal(typeof write.queryStream, 'undefined', 'write-only client does not expose queryStream function');
   assert.equal(typeof write.scanStream, 'undefined', 'write-only client does not expose scanStream function');
   assert.equal(typeof write.putStream, 'function', 'write-only client exposes putStream function');
@@ -220,7 +261,7 @@ test('[index] reuse client in multi method', function(assert) {
   assert.equal(multiDyno.config.read, multiDyno2.config.read, 'read config is reused');
   assert.equal(multiDyno.config.write, multiDyno2.config.write, 'write config is reused');
   assert.equal(multiDyno.read._client, multiDyno2.read._client, 'read client is reused');
-  assert.equal(multiDyno.write.client, multiDyno2.write.client, 'write client is reused');
+  assert.equal(multiDyno.write._client, multiDyno2.write._client, 'write client is reused');
   assert.end();
 });
 


### PR DESCRIPTION
Added async version of following methods:
- All native methods
  - listTablesAsync
  - describeTableAsync
  - batchGetItemAsync
  - batchWriteItemAsync
  - deleteItemAsync
  - getItemAsync
  - putItemAsync
  - updateItemAsync
- dynoExtensions
  - createTableAsync
  - deleteTableAsync
  - queryAsync
  - scanAsync